### PR TITLE
Fix NZ MMP overhang seat calculation and candidate name matching

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -67,9 +67,14 @@ const CSV_ELECTORATES = readFileSync(
   .map((s) => s.trim())
   .filter(Boolean);
 
+function normalizeName(name: string): string {
+  return name.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
 const partyMap: Record<string, string | undefined> = {};
 for (const row of candidateRecords) {
   partyMap[row.Name] = row.Party;
+  partyMap[normalizeName(row.Name)] = row.Party;
 }
 
 const POLL_INTERVAL_MS = parseInt(process.env.POLL_INTERVAL_MS || '120000', 10);
@@ -138,13 +143,20 @@ const run = async () => {
       for (const s of settled) {
         if (s.status === 'fulfilled') {
           const raw = source.parseRawResults(s.value.html, s.value.config);
+          const candidateVotes = raw.candidateVotes.map((cv) => {
+            const party =
+              partyMap[cv.candidate] ?? partyMap[normalizeName(cv.candidate)];
+            if (!party) {
+              log.debug(
+                `No party match for candidate "${cv.candidate}" in ${raw.electorateName}`
+              );
+            }
+            return { ...cv, party };
+          });
           const electorateResults = {
             electorateName: raw.electorateName,
             partyVotes: raw.partyVotes,
-            candidateVotes: raw.candidateVotes.map((cv) => ({
-              ...cv,
-              party: candidateRecords.find((r) => r.Name === cv.candidate)?.Party,
-            })),
+            candidateVotes,
             votesCounted: raw.votesCounted,
             votePercentageCounted: raw.votePercentageCounted,
           };

--- a/packages/cli/src/reducers.test.ts
+++ b/packages/cli/src/reducers.test.ts
@@ -1,8 +1,99 @@
 import { describe, expect, test } from 'vitest';
 import { calculatePartyVoteWithSeats } from '@election-night/core/reducers';
+import type { ElectorateResults, VotingResults, WithLeaders, WithPercentages } from '@election-night/core/types';
 import { electorateVotes, partyVotes } from './fixtures';
 
 describe('reducers', () => {
+  test('calculatePartyVoteWithSeats handles overhang seats', () => {
+    const pv: (VotingResults & WithPercentages)[] = [
+      { candidate: 'National Party', votes: 900_000, percentage: 0.45, marginOfError: 0 },
+      { candidate: 'Labour Party', votes: 700_000, percentage: 0.35, marginOfError: 0 },
+      { candidate: 'Te Pāti Māori', votes: 30_000, percentage: 0.015, marginOfError: 0 },
+    ];
+
+    const ev: (ElectorateResults & WithLeaders)[] = [
+      // Te Pāti Māori wins 6 electorates despite only ~1.5% party vote (entitlement ~2)
+      ...Array.from({ length: 6 }, (_, i) => ({
+        electorateName: `Māori ${i + 1}`,
+        partyVotes: [] as VotingResults[],
+        candidateVotes: [
+          { candidate: `TMP Candidate ${i + 1}`, votes: 10_000, party: 'Te Pāti Māori' },
+          { candidate: 'Labour', votes: 5_000, party: 'Labour Party' },
+        ],
+        votesCounted: 15_000,
+        votePercentageCounted: 1,
+        leaders: {
+          leadingCandidate: `TMP Candidate ${i + 1}`,
+          leadingCandidateParty: 'Te Pāti Māori' as string | undefined,
+          secondCandidate: 'Labour',
+          secondCandidateParty: 'Labour Party' as string | undefined,
+          margin: 5_000,
+          marginPercent: 0.33,
+          predictionStatus: 'projected' as const,
+        },
+      })),
+      // National wins 40 general electorates
+      ...Array.from({ length: 40 }, (_, i) => ({
+        electorateName: `General ${i + 1}`,
+        partyVotes: [] as VotingResults[],
+        candidateVotes: [
+          { candidate: `Nat Candidate ${i + 1}`, votes: 15_000, party: 'National Party' },
+          { candidate: 'Labour', votes: 10_000, party: 'Labour Party' },
+        ],
+        votesCounted: 25_000,
+        votePercentageCounted: 1,
+        leaders: {
+          leadingCandidate: `Nat Candidate ${i + 1}`,
+          leadingCandidateParty: 'National Party' as string | undefined,
+          secondCandidate: 'Labour',
+          secondCandidateParty: 'Labour Party' as string | undefined,
+          margin: 5_000,
+          marginPercent: 0.2,
+          predictionStatus: 'projected' as const,
+        },
+      })),
+      // Labour wins 14 electorates
+      ...Array.from({ length: 14 }, (_, i) => ({
+        electorateName: `Labour Gen ${i + 1}`,
+        partyVotes: [] as VotingResults[],
+        candidateVotes: [
+          { candidate: `Lab Candidate ${i + 1}`, votes: 12_000, party: 'Labour Party' },
+          { candidate: 'National', votes: 8_000, party: 'National Party' },
+        ],
+        votesCounted: 20_000,
+        votePercentageCounted: 1,
+        leaders: {
+          leadingCandidate: `Lab Candidate ${i + 1}`,
+          leadingCandidateParty: 'Labour Party' as string | undefined,
+          secondCandidate: 'National',
+          secondCandidateParty: 'National Party' as string | undefined,
+          margin: 4_000,
+          marginPercent: 0.2,
+          predictionStatus: 'projected' as const,
+        },
+      })),
+    ];
+
+    const actual = calculatePartyVoteWithSeats(pv, ev);
+
+    const tmp = actual.find((x) => x.candidate === 'Te Pāti Māori');
+    const national = actual.find((x) => x.candidate === 'National Party');
+    const labour = actual.find((x) => x.candidate === 'Labour Party');
+
+    // Te Pāti Māori has overhang: 6 electorates but entitlement < 6
+    expect(tmp!.electorateSeats).toBe(6);
+    expect(tmp!.seats).toBe(6);
+    expect(tmp!.listSeats).toBe(0);
+
+    // Total seats should exceed 120 because of overhang
+    const totalSeats = actual.reduce((s, p) => s + p.seats, 0);
+    expect(totalSeats).toBeGreaterThan(120);
+
+    // National and Labour should still receive list seats
+    expect(national!.seats).toBeGreaterThan(national!.electorateSeats);
+    expect(labour!.seats).toBeGreaterThan(labour!.electorateSeats);
+  });
+
   test('calculatePartyVoteWithSeats', () => {
     const actual = calculatePartyVoteWithSeats(partyVotes, electorateVotes);
     const expected = [

--- a/packages/core/src/reducers.ts
+++ b/packages/core/src/reducers.ts
@@ -193,16 +193,31 @@ function calculatePartyVoteWithSeats(
     },
     {} as Record<string, number>
   );
-  const seats =
+  const entitlement =
     Object.keys(resultsMap).length > 0
       ? sainteLague(resultsMap, 120, { draw: true })
       : {};
 
+  const finalSeats: Record<string, number> = {};
+  for (const party of Object.keys(entitlement)) {
+    finalSeats[party] = Math.max(
+      entitlement[party] || 0,
+      electorateSeats[party] || 0
+    );
+  }
+  // Parties with electorate wins but no party-vote entitlement keep those seats (overhang)
+  for (const party of Object.keys(electorateSeats)) {
+    if (!(party in finalSeats)) {
+      finalSeats[party] = electorateSeats[party];
+    }
+  }
+
   return partyVotes.map((x) => ({
     ...x,
-    seats: seats[x.candidate] || 0,
+    seats: finalSeats[x.candidate] || 0,
     electorateSeats: electorateSeats[x.candidate] || 0,
-    listSeats: (seats[x.candidate] || 0) - (electorateSeats[x.candidate] || 0),
+    listSeats:
+      (finalSeats[x.candidate] || 0) - (electorateSeats[x.candidate] || 0),
   }));
 }
 

--- a/packages/web/server/seed.ts
+++ b/packages/web/server/seed.ts
@@ -371,13 +371,28 @@ function calculatePartyVoteWithSeats(
     eligibleVotes[e.candidate] = e.votes;
   }
 
-  const seats = sainteLagueSimple(eligibleVotes, 120);
+  const entitlement = sainteLagueSimple(eligibleVotes, 120);
+
+  const finalSeats: Record<string, number> = {};
+  for (const party of Object.keys(entitlement)) {
+    finalSeats[party] = Math.max(
+      entitlement[party] || 0,
+      electorateSeats[party] || 0
+    );
+  }
+  // Parties with electorate wins but no party-vote entitlement keep those seats (overhang)
+  for (const party of Object.keys(electorateSeats)) {
+    if (!(party in finalSeats)) {
+      finalSeats[party] = electorateSeats[party];
+    }
+  }
 
   return partyVotes.map((x) => ({
     ...x,
-    seats: seats[x.candidate] || 0,
+    seats: finalSeats[x.candidate] || 0,
     electorateSeats: electorateSeats[x.candidate] || 0,
-    listSeats: (seats[x.candidate] || 0) - (electorateSeats[x.candidate] || 0),
+    listSeats:
+      (finalSeats[x.candidate] || 0) - (electorateSeats[x.candidate] || 0),
   }));
 }
 


### PR DESCRIPTION
Summary of changes
- packages/core/src/reducers.ts — calculatePartyVoteWithSeats now implements NZ MMP overhang: finalSeats = max(Sainte-Laguë entitlement, electorateSeats), so total seats correctly exceed 120 when a party wins more electorates than their party-vote share.
- packages/web/server/seed.ts — Applied the same overhang fix to the web server's seed logic.
- packages/cli/src/index.ts — Fixed fragile candidate name matching by adding a normalizeName() helper (trim, collapse spaces, lowercase). partyMap stores lookups for both exact and normalized names, so slight variations in scraped candidate names (common with Māori names) no longer fail to match.
- packages/cli/src/reducers.test.ts — Added an overhang scenario test (Te Pāti Māori winning 6 electorates on ~1.5% party vote) verifying correct seat totals, overhang handling, and non-negative list seats.