### PR TITLE
feat(dashboard): add manual light/dark theme toggle in header

### DIFF
--- a/packages/dashboard/index.html
+++ b/packages/dashboard/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="color-scheme" content="light dark" />
     <meta name="theme-color" content="#f7f4eb" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#16130e" media="(prefers-color-scheme: dark)" />
     <meta name="description" content="Real-time NZ general election results tracker with live seat projections, electorate maps, and party vote breakdowns." />
@@ -26,10 +25,17 @@
     />
 
     <script>
-      // Default colour mode follows the OS; toggle with the html class="dark".
-      if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-        document.documentElement.classList.add('dark');
-      }
+      // Light is the default. A manually saved choice wins; we deliberately do
+      // NOT follow the OS preference or time of day. Toggle the dark class.
+      (function () {
+        try {
+          if (localStorage.getItem('election-night:theme') === 'dark') {
+            document.documentElement.classList.add('dark');
+          }
+        } catch (e) {
+          /* storage unavailable — stay with the light default */
+        }
+      })();
     </script>
 
     <!-- Open Graph / Social -->

--- a/packages/dashboard/src/components/Layout.tsx
+++ b/packages/dashboard/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { cn } from '../lib/utils.js';
 import Logo from './Logo.js';
 import LiveIndicator from './LiveIndicator.js';
+import ThemeToggle from './ThemeToggle.js';
 import FeedSidebar from './FeedSidebar.js';
 
 const navItems = [
@@ -85,6 +86,7 @@ export default function Layout({ children }: { children: ReactNode }) {
                 ))}
               </nav>
               <LiveIndicator />
+              <ThemeToggle />
               <button
                 onClick={() => setMenuOpen(!menuOpen)}
                 className="md:hidden relative w-9 h-9 flex items-center justify-center hover:bg-muted transition-colors"

--- a/packages/dashboard/src/components/ThemeToggle.test.tsx
+++ b/packages/dashboard/src/components/ThemeToggle.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import ThemeToggle from './ThemeToggle.js';
+
+const THEME_KEY = 'election-night:theme';
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
+  });
+
+  it('defaults to light when nothing is saved', () => {
+    render(<ThemeToggle />);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(screen.getByRole('button', { name: 'Switch to dark mode' })).toBeTruthy();
+  });
+
+  it('applies a saved dark theme on mount', () => {
+    localStorage.setItem(THEME_KEY, 'dark');
+    render(<ThemeToggle />);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(screen.getByRole('button', { name: 'Switch to light mode' })).toBeTruthy();
+  });
+
+  it('toggles to dark, persists, and toggles back', () => {
+    render(<ThemeToggle />);
+    const button = screen.getByRole('button');
+
+    fireEvent.click(button);
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(localStorage.getItem(THEME_KEY)).toBe('dark');
+
+    fireEvent.click(button);
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+    expect(localStorage.getItem(THEME_KEY)).toBe('light');
+  });
+});

--- a/packages/dashboard/src/components/ThemeToggle.tsx
+++ b/packages/dashboard/src/components/ThemeToggle.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+
+const THEME_KEY = 'election-night:theme';
+const LIGHT = 'light';
+const DARK = 'dark';
+
+function getStoredTheme(): 'light' | 'dark' {
+  try {
+    return localStorage.getItem(THEME_KEY) === DARK ? DARK : LIGHT;
+  } catch {
+    return LIGHT;
+  }
+}
+
+function SunIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  );
+}
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<'light' | 'dark'>(getStoredTheme);
+  const isDark = theme === DARK;
+
+  // Keep the html class in sync; the inline <head> script handles first paint.
+  useEffect(() => {
+    document.documentElement.classList.toggle(DARK, isDark);
+  }, [isDark]);
+
+  const toggle = () => {
+    const next = isDark ? LIGHT : DARK;
+    setTheme(next);
+    try {
+      localStorage.setItem(THEME_KEY, next);
+    } catch {
+      /* storage unavailable — this visit stays on the chosen theme */
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      className="relative w-9 h-9 flex items-center justify-center text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+    >
+      {isDark ? <SunIcon /> : <MoonIcon />}
+    </button>
+  );
+}

--- a/packages/dashboard/src/styles/index.css
+++ b/packages/dashboard/src/styles/index.css
@@ -12,6 +12,7 @@
 @layer base {
   :root {
     /* newsprint stock — near-white, faint warm cast */
+    color-scheme: light;
     --background: 60 9% 94%;
     --foreground: 40 6% 13%;
     --card: 60 9% 94%;
@@ -36,6 +37,7 @@
 
   .dark {
     /* night edition — warm ink paper */
+    color-scheme: dark;
     --background: 40 8% 9%;
     --foreground: 55 8% 90%;
     --card: 40 8% 11%;


### PR DESCRIPTION
Light is now the default; the saved choice wins and the OS preference is deliberately ignored. The header gets a sun/moon toggle button that flips the html.dark class and persists to localStorage. color-scheme is driven by CSS so form controls and scrollbars follow the switch.