### PR TITLE
fix(dashboard): bump live feed commentary font size in sidebar

### DIFF
--- a/packages/dashboard/src/components/FeedSidebar.tsx
+++ b/packages/dashboard/src/components/FeedSidebar.tsx
@@ -70,7 +70,7 @@ function SidebarEvent({ event }: { event: FeedEvent }) {
           </span>
         </div>
         {event.commentary && (
-          <p className="text-xs text-foreground/70 mt-0.5 leading-snug">
+          <p className="text-sm text-foreground/70 mt-0.5 leading-snug">
             {event.commentary}
           </p>
         )}


### PR DESCRIPTION
Sidebar commentary was text-xs while the /feed page used text-sm; match the feed page for readability and consistency.