### PR TITLE
feat(collector): fall back to cached electorate results on scrape failure

### DIFF
--- a/packages/collector/src/metrics.test.ts
+++ b/packages/collector/src/metrics.test.ts
@@ -20,6 +20,10 @@ describe('collector metric events', () => {
       metric: 'scrapeElectoratesTotal',
       status: 'error',
     });
+    expect(emitScrapeElectorate('cached')).toEqual({
+      metric: 'scrapeElectoratesTotal',
+      status: 'cached',
+    });
   });
 
   it('emits socket connection events', () => {

--- a/packages/collector/src/metrics.ts
+++ b/packages/collector/src/metrics.ts
@@ -7,7 +7,9 @@ export function emitScrapeDuration(
   return { metric: 'scrapeDurationSeconds', seconds, status };
 }
 
-export function emitScrapeElectorate(status: 'success' | 'error'): MetricEvent {
+export function emitScrapeElectorate(
+  status: 'success' | 'error' | 'cached'
+): MetricEvent {
   return { metric: 'scrapeElectoratesTotal', status };
 }
 

--- a/packages/collector/src/results.ts
+++ b/packages/collector/src/results.ts
@@ -26,7 +26,7 @@ export function cacheResults(toCache: Results[]) {
   );
 }
 
-function readResults(): Results[] {
+export function readResults(): Results[] {
   if (electorateResults) {
     return electorateResults;
   }
@@ -149,13 +149,9 @@ export async function sendWebhook(
  * Call this *before* calling `cacheResults()` so the cached snapshot still
  * represents the previous cycle for comparison.
  */
-export async function processResults(
-  currentResults: Results[]
-): Promise<void> {
+export async function processResults(currentResults: Results[]): Promise<void> {
   const cachedResults = readResults();
-  const cacheMap = new Map(
-    cachedResults.map((r) => [r.electorateName, r])
-  );
+  const cacheMap = new Map(cachedResults.map((r) => [r.electorateName, r]));
 
   const promises: Promise<void>[] = [];
 

--- a/packages/collector/src/scrape-cycle.ts
+++ b/packages/collector/src/scrape-cycle.ts
@@ -18,6 +18,7 @@ import {
 import { log } from './logger.js';
 import { getElectoratePageHtml } from './scraper.js';
 import { publishMetrics } from './ws-client.js';
+import { readResults } from './results.js';
 import { emitScrapeDuration, emitScrapeElectorate } from './metrics.js';
 
 export type ScrapeCycleOptions = {
@@ -47,6 +48,9 @@ export async function scrapeCycle(
   log.info('Starting election results scraping...');
   const start = performance.now();
 
+  const cachedResults = readResults();
+  const cachedByName = new Map(cachedResults.map((r) => [r.electorateName, r]));
+
   const settled = await Promise.allSettled(
     configs.map((cfg) =>
       limit(() =>
@@ -59,7 +63,12 @@ export async function scrapeCycle(
   );
 
   const results: ElectorateResults[] = [];
-  for (const s of settled) {
+  type ElectorateSource = 'fresh' | 'cached' | 'failed';
+  const electorateSources: ElectorateSource[] = [];
+
+  for (let i = 0; i < settled.length; i++) {
+    const s = settled[i];
+    const cfg = configs[i];
     if (s.status === 'fulfilled') {
       const raw = source.parseRawResults(s.value.html, s.value.config);
       const electorateResults: ElectorateResults = {
@@ -86,14 +95,25 @@ export async function scrapeCycle(
         }
       }
       results.push(electorateResults);
+      electorateSources.push('fresh');
     } else {
-      log.error(`Failed to scrape electorate`, s.reason);
+      const cached = cachedByName.get(cfg.electorateName);
+      if (cached) {
+        log.warn(
+          `${cfg.electorateName}: scrape failed (${s.reason}); using cached result from previous poll`
+        );
+        results.push(cached);
+        electorateSources.push('cached');
+      } else {
+        log.error(`Failed to scrape electorate`, s.reason);
+        electorateSources.push('failed');
+      }
     }
   }
 
   const totalVotes = results.reduce((s, r) => s + (r.votesCounted || 0), 0);
   log.info(
-    `Finished scraping ${results.length}/${configs.length} electorates (total votes counted: ${totalVotes.toLocaleString()})`
+    `Finished with ${results.length}/${configs.length} electorates (total votes counted: ${totalVotes.toLocaleString()})`
   );
   if (results.length > 0) {
     const zeroVoteElectorates = results.filter(
@@ -148,15 +168,18 @@ export async function scrapeCycle(
   log.debug(`${totalListCandidates} list candidates above the cut`);
 
   const duration = (performance.now() - start) / 1000;
+  const freshCount = electorateSources.filter((s) => s === 'fresh').length;
   const status: 'success' | 'partial' | 'error' =
-    results.length === configs.length
+    freshCount === configs.length
       ? 'success'
       : results.length > 0
         ? 'partial'
         : 'error';
   const events = [emitScrapeDuration(duration, status)];
-  for (const s of settled) {
-    events.push(emitScrapeElectorate(s.status === 'fulfilled' ? 'success' : 'error'));
+  for (const source of electorateSources) {
+    const electorateStatus =
+      source === 'fresh' ? 'success' : source === 'failed' ? 'error' : 'cached';
+    events.push(emitScrapeElectorate(electorateStatus));
   }
   publishMetrics(events);
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -112,7 +112,11 @@ export type WebhookPayload = {
 
 // ---- Feed / Commentary ----
 
-export type FeedEventType = 'result_updated' | 'prediction_called' | 'leader_change' | 'count_completed';
+export type FeedEventType =
+  | 'result_updated'
+  | 'prediction_called'
+  | 'leader_change'
+  | 'count_completed';
 
 export type ElectorateDiff = {
   electorateName: string;
@@ -152,6 +156,6 @@ export type MetricEvent =
       seconds: number;
       status: 'success' | 'partial' | 'error';
     }
-  | { metric: 'scrapeElectoratesTotal'; status: 'success' | 'error' }
+  | { metric: 'scrapeElectoratesTotal'; status: 'success' | 'error' | 'cached' }
   | { metric: 'collectorSocketConnected'; connected: boolean }
   | { metric: 'webhookPublishesTotal'; status: 'success' | 'error' };

--- a/packages/dashboard/src/test/metrics.test.ts
+++ b/packages/dashboard/src/test/metrics.test.ts
@@ -17,6 +17,7 @@ describe('dashboard metrics', () => {
     applyMetricEvents([
       { metric: 'scrapeDurationSeconds', seconds: 1.23, status: 'success' },
       { metric: 'scrapeElectoratesTotal', status: 'success' },
+      { metric: 'scrapeElectoratesTotal', status: 'cached' },
       { metric: 'scrapeElectoratesTotal', status: 'error' },
       { metric: 'collectorSocketConnected', connected: true },
       { metric: 'webhookPublishesTotal', status: 'success' },
@@ -24,12 +25,25 @@ describe('dashboard metrics', () => {
 
     const output = await metricsResponse();
 
-    expect(output).toContain('election_scrape_duration_seconds_sum{status="success"} 1.23');
-    expect(output).toContain('election_scrape_duration_seconds_count{status="success"} 1');
-    expect(output).toContain('election_scrape_electorates_total{status="success"} 1');
-    expect(output).toContain('election_scrape_electorates_total{status="error"} 1');
+    expect(output).toContain(
+      'election_scrape_duration_seconds_sum{status="success"} 1.23'
+    );
+    expect(output).toContain(
+      'election_scrape_duration_seconds_count{status="success"} 1'
+    );
+    expect(output).toContain(
+      'election_scrape_electorates_total{status="success"} 1'
+    );
+    expect(output).toContain(
+      'election_scrape_electorates_total{status="cached"} 1'
+    );
+    expect(output).toContain(
+      'election_scrape_electorates_total{status="error"} 1'
+    );
     expect(output).toContain('election_collector_socket_connected 1');
-    expect(output).toContain('election_webhook_publishes_total{status="success"} 1');
+    expect(output).toContain(
+      'election_webhook_publishes_total{status="success"} 1'
+    );
   });
 
   it('tracks dashboard-only gauges directly', async () => {
@@ -41,9 +55,15 @@ describe('dashboard metrics', () => {
     const output = await metricsResponse();
 
     expect(output).toContain('election_websocket_clients_connected 5');
-    expect(output).toContain('election_last_scrape_timestamp_seconds 1234567890');
-    expect(output).toContain('election_feed_events_total{type="leader_change"} 1');
-    expect(output).toContain('election_feed_events_total{type="result_updated"} 1');
+    expect(output).toContain(
+      'election_last_scrape_timestamp_seconds 1234567890'
+    );
+    expect(output).toContain(
+      'election_feed_events_total{type="leader_change"} 1'
+    );
+    expect(output).toContain(
+      'election_feed_events_total{type="result_updated"} 1'
+    );
   });
 
   it('marks the collector as disconnected when no metrics have arrived recently', async () => {


### PR DESCRIPTION
## Summary

When an electorate request times out (or otherwise fails) during a scrape cycle, the collector currently **excludes** that electorate from the results payload. This creates gaps in the dashboard (missing electorates, skewed party-vote totals).

This PR changes the behavior so the prior poll's cached result is used instead, with a warning logged.

## Changes

- **`packages/collector/src/scrape-cycle.ts`**
  - Loads the previous cycle's cached results (`readResults()`) at the start of each cycle.
  - On any failed electorate fetch:
    - **Cached data available** → logs a warning and includes the prior result (no gap).
    - **No cached data** (e.g. first cycle) → logs an error and excludes it, as before.
  - Tracks each electorate as `fresh` / `cached` / `failed`.
  - Cycle status is now based on *freshly scraped* count:
    - `success` — all electorates freshly scraped
    - `partial` — some used cached data or failed entirely
    - `error` — no electorate data at all

- **`packages/collector/src/results.ts`** — exports `readResults()` so the scrape cycle can access the previous cycle's cache.

- **Metrics** — new `cached` status added to the `scrapeElectoratesTotal` metric (`packages/core/src/types.ts`, `packages/collector/src/metrics.ts`), so stale fallback data is observable in Prometheus.

## Behaviour notes

- Webhook diffing (`processResults`) compares the old cache against the current payload — a fallback electorate produces previous == current, so no spurious events fire.
- Cached results still flow through the prediction pipeline (`calculateLead` / `predictWinner`), reproducing the same leaders/prediction from identical inputs.
- A Puppeteer navigation timeout now yields a warning + stable dashboard instead of a missing electorate.

## Example warning

```
<ElectorateName>: scrape failed (TimeoutError: Navigation timeout of 60000 ms exceeded); using cached result from previous poll
```

## Verification

- `npm run build:core` ✓
- `npm run typecheck` ✓
- `npm test` — 193 passed ✓
- `npm run lint` ✓
