### PR TITLE
feat(ci): deploy to Fly on push to main

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,6 +1,7 @@
 name: Code checks
 
 on:
+  workflow_call:
   workflow_dispatch:
   pull_request:
     branches:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,64 @@
+name: Deploy production
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      deploy: ${{ steps.filter.outputs.deploy }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad # v3.0.4
+        id: filter
+        with:
+          filters: |
+            deploy:
+              - 'Dockerfile'
+              - 'fly.toml'
+              - 'deploy/**'
+              - 'packages/**'
+              - 'csv/**'
+              - 'tsconfig*.json'
+              - 'package.json'
+              - 'package-lock.json'
+              - '.dockerignore'
+              - '.github/workflows/checks.yml'
+              - '.github/workflows/deploy.yml'
+
+  check:
+    name: Lint, typecheck & test
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.deploy == 'true'
+    uses: ./.github/workflows/checks.yml
+
+  deploy:
+    name: Deploy to Fly
+    needs: [changes, check]
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.deploy == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # v1.6
+
+      - name: Deploy to Fly
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: flyctl deploy --remote-only --image-label "main-${{ github.sha }}"
+
+      - name: Smoke test
+        run: |
+          curl -fsS --retry 10 --retry-delay 5 --retry-all-errors https://election-night.fly.dev/health
+          curl -fsS --retry 3 --retry-delay 5 --retry-all-errors https://election-night.fly.dev/ready

--- a/fly.toml
+++ b/fly.toml
@@ -34,11 +34,9 @@ primary_region = "nrt"
   DB_PATH = "/app/.data/election_results.db"
 
 # Shared persistent storage for SQLite DB and JSON cache.
-# Create the volume first: fly volumes create election_data --region nrt --size 1
-# Then uncomment the mount below:
-# [[mounts]]
-#   source = "election_data"
-#   destination = "/app/.data"
+[[mounts]]
+  source = "election_data"
+  destination = "/app/.data"
 
 [[vm]]
   memory = "1gb"


### PR DESCRIPTION
Deploys the production app to Fly.io on push to main (and manually), gated on CI.

## Pipeline

```
push → main ─┬─▶ changes (dorny/paths-filter) ──┬─▶ check (reuses checks.yml) ─▶ deploy → Fly → smoke test
             └─ workflow_dispatch (manual) ─────┘
```

- **`changes`** — `dorny/paths-filter` skips the whole pipeline for docs-only commits (README, AGENTS.md, etc.). Deploy-relevant paths: `Dockerfile`, `fly.toml`, `deploy/**`, `packages/**`, `csv/**`, `tsconfig*.json`, `package*.json`, `.dockerignore`, the workflows themselves.
- **`check`** — reuses `checks.yml` via `workflow_call` (added `workflow_call` to its triggers): lint/typecheck/193 tests must be green before anything deploys. Manual dispatch bypasses the paths filter.
- **`deploy`** — `flyctl deploy --remote-only --image-label "main-$sha"` (remote build on Fly's builders; fly.toml supplies app name, region, `/health` check, env).
- **Smoke test** — curls `/health` and `/ready` on `https://election-night.fly.dev` after deploy.

## Hardening

- All actions SHA-pinned (checkout v6, paths-filter v3.0.4, flyctl-actions v1.6)
- Least-privilege `contents: read`
- `concurrency: cancel-in-progress: false` — rapid pushes serialize instead of racing mid-deploy

## Also in this PR

- **`fly.toml`**: mounts the `election_data` volume at `/app/.data` (volume already created in `nrt`) so the SQLite DB and JSON caches persist across deploys instead of being wiped with each machine replacement.
- No migration step needed — the collector auto-runs Drizzle migrations on startup.

## Note

The `deploy` job can only be exercised once merged (push-to-main trigger); the workflow structure mirrors the already-green `checks.yml`/`security.yml`, and `flyctl config validate` passes.
