### PR TITLE
fix(fly): speed up deploy startup and fix smoke test false-failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,5 +60,10 @@ jobs:
 
       - name: Smoke test
         run: |
-          curl -fsS --retry 10 --retry-delay 5 --retry-all-errors https://election-night.fly.dev/health
-          curl -fsS --retry 3 --retry-delay 5 --retry-all-errors https://election-night.fly.dev/ready
+          # /health can briefly 503 while the Fly edge routes to the new machine
+          # (~15-20s observed). Window: ~100s.
+          curl -fsS --retry 20 --retry-delay 5 --retry-all-errors https://election-night.fly.dev/health
+          # /ready stays 503 until the collector's first full scrape cycle
+          # publishes a feed event (browser cache + concurrency 2 on a 1GB VM:
+          # ~2-5 min). Window: ~5 min.
+          curl -fsS --retry 30 --retry-delay 10 --retry-all-errors https://election-night.fly.dev/ready

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:22 AS builder
 WORKDIR /app
 
-ENV CLOAKBROWSER_CACHE_DIR=/app/.data/cloakbrowser
+ENV CLOAKBROWSER_CACHE_DIR=/app/.cloakbrowser
 ENV CLOAKBROWSER_AUTO_UPDATE=false
 
 COPY package.json package-lock.json ./
@@ -36,7 +36,7 @@ RUN npx esbuild packages/dashboard/server/index.ts \
 FROM node:22-slim
 WORKDIR /app
 ENV NODE_ENV=production
-ENV CLOAKBROWSER_CACHE_DIR=/app/.data/cloakbrowser
+ENV CLOAKBROWSER_CACHE_DIR=/app/.cloakbrowser
 ENV CLOAKBROWSER_AUTO_UPDATE=false
 
 RUN apt-get update && apt-get install -y \

--- a/fly.toml
+++ b/fly.toml
@@ -29,7 +29,7 @@ primary_region = "nrt"
   BASE_RESULTS_URL = "https://www.electionresults.govt.nz/electionresults_2023"
   WS_URL = "ws://localhost:3456"
   POLL_INTERVAL_MS = "120000"
-  CONCURRENCY = "1"
+  CONCURRENCY = "2"
   LOG_LEVEL = "3"
   DB_PATH = "/app/.data/election_results.db"
 

--- a/packages/collector/src/scrape-cycle.ts
+++ b/packages/collector/src/scrape-cycle.ts
@@ -53,12 +53,21 @@ export async function scrapeCycle(
 
   const settled = await Promise.allSettled(
     configs.map((cfg) =>
-      limit(() =>
-        getElectoratePageHtml(browser, cfg).then((html) => ({
-          html,
-          config: cfg,
-        }))
-      )
+      limit(async () => {
+        const startedAt = performance.now();
+        try {
+          const html = await getElectoratePageHtml(browser, cfg);
+          return { html, config: cfg };
+        } catch (reason) {
+          const elapsed = ((performance.now() - startedAt) / 1000).toFixed(1);
+          const detail =
+            reason instanceof Error ? reason.message : String(reason);
+          log.error(
+            `${cfg.electorateName}: fetch failed after ${elapsed}s (${detail})`
+          );
+          throw reason;
+        }
+      })
     )
   );
 


### PR DESCRIPTION
Fixes the two problems surfaced by the first production deploy: the slow startup before scraping, and the smoke test that false-failed.

## 1. Browser was re-downloading on every machine start

`CLOAKBROWSER_CACHE_DIR=/app/.data/cloakbrowser` sat **under the fly.toml volume mount** (`/app/.data`). The volume shadows the image layer, so the Chromium downloaded at build time was invisible at runtime — the collector re-downloaded the whole browser on every boot (the 20+ min pause before scraping on the 1GB VM).

**Fix:** moved the cache to `/app/.cloakbrowser` (image layer, untouched by the volume) in both Dockerfile stages. Startup goes straight to scraping; the volume only holds the SQLite DB and JSON caches.

## 2. Concurrency 1 → 2

One shared browser, `pLimit(CONCURRENCY)` tabs. At 1GB/1cpu, concurrency 2 is the safe ceiling (~600–750MB peak, est. per-renderer 100–150MB over a ~450–550MB base); 3+ risks OOM. Halves first-cycle time (~120→~60 batches).

## 3. Smoke test false-failure

The old `/ready` check retried 3×5s = 15s, but `/ready` legitimately stays 503 until the collector's first full cycle publishes a feed event (minutes, not seconds). Observed failure was: `/health` 503'd ~16s (edge warmup) then passed; `/ready` failed instantly.

**Fix:** `/health` keeps a ~100s window (edge warmup); `/ready` now polls ~5 min (`--retry 30 --retry-delay 10`), matching the browser-cache + concurrency-2 timeline.

Verified: `flyctl config validate` passes; YAML parses; the running app is at `LOG_LEVEL=2` (set via secret) showing per-electorate debug logs.
