### PR TITLE
Apply code review fixes across collector, dashboard server, and frontend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,7 +12,8 @@
 .git
 .gitignore
 .env
-.env.local
+.env.*
+!.env.example
 .vscode
 *.md
 .DS_Store

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,6 @@
 # Scraping
+# Points at the local mock server by default. For the real site, set
+# BASE_RESULTS_URL=https://electionresults.govt.nz/electionresults_2023
 BASE_RESULTS_URL=http://localhost:3457
 RESULTS_TABLE_SELECTOR=
 CANDIDATE_TABLE_SELECTOR=
@@ -17,8 +19,8 @@ CHALLENGE_WARMUP_ENABLED=true
 LOG_LEVEL=3
 WS_RECONNECT_DELAY_MS=2000
 
-# Collector health/live-state endpoint (Docker HEALTHCHECK / Coolify).
-# Also hosts the /history/* REST endpoints that the cloud dashboard server
+# Collector health/live-state endpoint (e.g. Docker HEALTHCHECK).
+# Also hosts the /history/* REST endpoints that the dashboard server
 # reads. The data is public election results; endpoints are per-IP rate
 # limited rather than token protected.
 HEALTH_PORT=3459
@@ -36,6 +38,8 @@ WS_URL=
 
 # Database
 DB_PATH=.data/election_results.db
+# JSON cache of the last-cycle electorate results (webhook diff baseline)
+RESULTS_CACHE_PATH=.data/electorate_results.json
 
 # Custom source adapter
 ELECTION_SOURCE_PATH=
@@ -58,8 +62,13 @@ DIST_DIR=
 CACHE_PATH=.data/electorate_results.json
 FEED_CACHE_PATH=.data/feed_events.json
 MAX_FEED_EVENTS=200
+# When set, POST /api/clear requires this shared secret in the x-clear-token
+# header. Leave unset to keep the clear endpoint open (not recommended).
+CLEAR_TOKEN=
+# Frontend Socket.io URL override (defaults to the current origin)
+VITE_WS_URL=
 
 # History API — always fetched from the collector's /history/* REST API.
-# Default suits a co-located collector; point at the homelab collector
+# Default suits a co-located collector; point it at the collector
 # (e.g. https://history.example.com) in split deployments.
 HISTORY_UPSTREAM=http://127.0.0.1:3459

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ node_modules
 .data
 .vscode
 .env
+.env.*
+!.env.example
 dist
 *.db
 *.tsbuildinfo

--- a/fly.toml
+++ b/fly.toml
@@ -23,9 +23,12 @@ primary_region = "syd"
   port = 3456
   path = "/metrics"
 
-# Server-only app: the collector runs on the homelab and publishes results
-# over Socket.io (WS_URL) plus history over HTTP (set HISTORY_UPSTREAM via
-# `fly secrets set` to point at the homelab's history endpoint).
+# Server-only app: the collector runs elsewhere and publishes results
+# over Socket.io (WS_URL) plus history over HTTP. HISTORY_UPSTREAM is
+# REQUIRED for history data — set it via `fly secrets set` to point at the
+# collector's history endpoint (e.g. https://history.example.com). Without
+# it the server defaults to http://127.0.0.1:3459, which is unreachable
+# inside Fly, so the Trends page and /ready will show no history.
 [env]
   NODE_ENV = "production"
   DIST_DIR = "/app/packages/dashboard/dist"

--- a/packages/collector/src/clear.ts
+++ b/packages/collector/src/clear.ts
@@ -18,8 +18,7 @@ const TABLES_IN_ORDER = [
 const CACHE_FILES = [resolve(process.cwd(), collectorConfig.resultsCachePath)];
 
 export async function runClear(): Promise<void> {
-  const dbPath =
-    process.env.DB_PATH || resolve(process.cwd(), '.data/election_results.db');
+  const dbPath = resolve(process.cwd(), collectorConfig.dbPath);
 
   log.info('=== Clear: starting ===');
 

--- a/packages/collector/src/db.ts
+++ b/packages/collector/src/db.ts
@@ -81,7 +81,11 @@ export function writeResults(
           scrapeId,
           electorate: r.electorateName,
           votesCounted: r.votesCounted,
-          estimatedTotalVotes: r.votesCounted / r.votePercentageCounted,
+          estimatedTotalVotes:
+            r.votePercentageCounted > 0 &&
+            Number.isFinite(r.votePercentageCounted)
+              ? r.votesCounted / r.votePercentageCounted
+              : 0,
           votePctCounted: r.votePercentageCounted,
           leadingCandidate: r.leaders.leadingCandidate,
           leadingParty: r.leaders.leadingCandidateParty,
@@ -94,7 +98,9 @@ export function writeResults(
           marginPct: r.leaders.marginPercent,
           secondCandidate: r.leaders.secondCandidate,
           secondParty: r.leaders.secondCandidateParty,
-          marginOfError: r.marginOfError,
+          marginOfError: Number.isFinite(r.marginOfError)
+            ? r.marginOfError
+            : null,
         })
         .run();
 

--- a/packages/collector/src/health.ts
+++ b/packages/collector/src/health.ts
@@ -29,11 +29,13 @@ export const health: CollectorHealthState = {
 };
 
 /**
- * Tiny state server (node:http, no deps) so Coolify can healthcheck the
+ * Tiny state server (node:http, no deps) so container orchestrators can healthcheck the
  * worker and we can inspect live state on election night. Binds 0.0.0.0 so
  * in-container probes, the reverse proxy, and the history REST
  * routes (mounted via `handleRoute`) can all reach it. `/health` stays open
- * (nothing sensitive); `/history/*` are rate limited per IP.
+ * (nothing sensitive). `/history/*` are unauthenticated and are NOT rate
+ * limited in-process — rate limiting belongs at the reverse proxy / firewall
+ * in front of the collector.
  */
 export function startHealthServer(
   port: number,

--- a/packages/collector/src/index.ts
+++ b/packages/collector/src/index.ts
@@ -1,5 +1,6 @@
 import 'dotenv/config';
 import { launch } from 'cloakbrowser';
+import type { ElectorateConfig, ElectionSource, PartyList } from '@election-night/core/types';
 import { log } from './logger.js';
 import { openDb, closeDb, writeResults } from './db.js';
 import { connectWs, publishResults, disconnectWs } from './ws-client.js';
@@ -31,13 +32,15 @@ const {
   dbPath,
 } = collectorConfig;
 
-const { candidateRecords, partyListRecords, electorateNames, partyMap } =
-  loadCsvData();
+let candidateRecords: Record<string, string>[] = [];
+let partyListRecords: PartyList[] = [];
+let electorateNames: string[] = [];
+let partyMap: Record<string, string | undefined> = {};
+let source: ElectionSource;
+let electorateConfigs: ElectorateConfig[] = [];
 
-const { source, configs: electorateConfigs } =
-  await loadSource(electorateNames);
-
-log.info('=== Scraper Configuration ===');
+function logConfiguration(): void {
+  log.info('=== Scraper Configuration ===');
 log.info(`DB_PATH:          ${collectorConfig.dbPath}`);
 log.info(
   `BASE_RESULTS_URL: ${collectorConfig.baseResultsUrl || 'https://electionresults.govt.nz/electionresults_2023'}`
@@ -65,8 +68,9 @@ if (collectorConfig.webhookUrl)
   log.info(`WEBHOOK_URL:      ${collectorConfig.webhookUrl}`);
 if (collectorConfig.electionSourcePath)
   log.info(`ELECTION_SOURCE:   ${collectorConfig.electionSourcePath}`);
-log.info(`Electorates:      ${electorateConfigs.length}`);
-log.info('=============================');
+  log.info(`Electorates:      ${electorateConfigs.length}`);
+  log.info('=============================');
+}
 
 async function runOnce(): Promise<void> {
   health.cycleCount += 1;
@@ -114,13 +118,13 @@ async function runOnce(): Promise<void> {
       concurrency: CONCURRENCY,
     });
 
-    await processResults(payload.electorateResults);
-    cacheResults(payload.electorateResults);
     writeResults(
       payload.electorateResults,
       payload.partyVote,
       payload.partyLists
     );
+    await processResults(payload.electorateResults);
+    cacheResults(payload.electorateResults);
     publishResults(payload);
     health.lastCycleFinishedAt = Date.now();
     health.lastCycleOk = true;
@@ -157,20 +161,58 @@ process.on('unhandledRejection', (reason) => {
     (reason.message.includes('TargetCloseError') ||
       reason.message.includes('Protocol error'))
   ) {
+    log.warn('Ignored browser rejection', reason);
     return;
   }
   log.error('Unhandled rejection', reason);
 });
 
-openDb(dbPath);
-connectWs(WS_URL);
-startHealthServer(
-  collectorConfig.healthPort,
-  createHistoryHandler({
-    dbPath: collectorConfig.dbPath,
-  })
-);
-loopRun().catch((err) => log.error('Fatal error in loop', err));
+async function main(): Promise<void> {
+  try {
+    ({ candidateRecords, partyListRecords, electorateNames, partyMap } =
+      loadCsvData());
+  } catch (err) {
+    log.error('Failed to load CSV data', err);
+    process.exit(1);
+  }
+
+  try {
+    ({ source, configs: electorateConfigs } = await loadSource(electorateNames));
+  } catch (err) {
+    log.error('Failed to load election source', err);
+    process.exit(1);
+  }
+
+  logConfiguration();
+
+  try {
+    openDb(dbPath);
+  } catch (err) {
+    log.error('Failed to open database', err);
+    process.exit(1);
+  }
+
+  connectWs(WS_URL);
+
+  try {
+    startHealthServer(
+      collectorConfig.healthPort,
+      createHistoryHandler({
+        dbPath: collectorConfig.dbPath,
+      })
+    );
+  } catch (err) {
+    log.error('Failed to start health server', err);
+    process.exit(1);
+  }
+
+  loopRun().catch((err) => {
+    log.error('Fatal error in scrape loop', err);
+    process.exit(1);
+  });
+}
+
+main();
 
 process.on('SIGINT', () => {
   disconnectWs();

--- a/packages/collector/src/results.ts
+++ b/packages/collector/src/results.ts
@@ -14,6 +14,7 @@ import { fetchWithRetry } from './retry.js';
 import { publishMetrics } from './ws-client.js';
 import { emitWebhookPublish } from './metrics.js';
 import { collectorConfig } from './config.js';
+import { log } from './logger.js';
 
 export type Results = ComparableResult;
 
@@ -76,8 +77,8 @@ export async function sendWebhook(
     publishMetrics(emitWebhookPublish('success'));
   } catch (e) {
     publishMetrics(emitWebhookPublish('error'));
-    console.error(
-      `Webhook POST failed for ${event} on ${result.electorateName} after retries:`,
+    log.error(
+      `Webhook POST failed for ${event} on ${result.electorateName} after retries`,
       e
     );
   }

--- a/packages/collector/src/retry.ts
+++ b/packages/collector/src/retry.ts
@@ -35,5 +35,11 @@ export function fetchWithRetry(
   init: RequestInit,
   options: RetryOptions = {}
 ): Promise<Response> {
-  return withRetry(() => fetch(url, init), options);
+  return withRetry(async () => {
+    const res = await fetch(url, init);
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status}`);
+    }
+    return res;
+  }, options);
 }

--- a/packages/collector/src/scrape-cycle.test.ts
+++ b/packages/collector/src/scrape-cycle.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { scrapeCycle } from './scrape-cycle.js';
+import type { BrowserContext } from 'playwright-core';
+import type { ElectionSource, ElectorateConfig } from '@election-night/core/types';
+
+const mockGetElectoratePageHtml = vi.fn();
+const mockIsCloudflareChallenge = vi.fn();
+const mockReadResults = vi.fn();
+const mockPublishMetrics = vi.fn();
+
+vi.mock('./scraper.js', () => ({
+  getElectoratePageHtml: (...args: unknown[]) => mockGetElectoratePageHtml(...args),
+  isCloudflareChallenge: (...args: unknown[]) => mockIsCloudflareChallenge(...args),
+}));
+
+vi.mock('./results.js', () => ({
+  readResults: () => mockReadResults(),
+}));
+
+vi.mock('./ws-client.js', () => ({
+  publishMetrics: (...args: unknown[]) => mockPublishMetrics(...args),
+}));
+
+describe('scrapeCycle', () => {
+  beforeEach(() => {
+    mockGetElectoratePageHtml.mockReset();
+    mockIsCloudflareChallenge.mockReset();
+    mockReadResults.mockReset();
+    mockPublishMetrics.mockReset();
+    mockReadResults.mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('treats a Cloudflare challenge page as a failed fetch and falls back to cached results', async () => {
+    const config: ElectorateConfig = {
+      electorateName: 'Auckland Central',
+      url: 'https://example.test/electorate-details-01.html',
+    };
+
+    mockGetElectoratePageHtml.mockResolvedValue('<html>challenge</html>');
+    mockIsCloudflareChallenge.mockReturnValue(true);
+
+    const source: ElectionSource = {
+      getElectorateConfigs: () => [config],
+      parseRawResults: vi.fn().mockReturnValue({
+        electorateName: 'Auckland Central',
+        candidateVotes: [{ candidate: 'Alice', votes: 1000 }],
+        partyVotes: [{ candidate: 'Red Party', votes: 1000 }],
+        votesCounted: 1000,
+        votePercentageCounted: 0.5,
+      }),
+    };
+
+    const payload = await scrapeCycle({
+      context: {} as BrowserContext,
+      source,
+      configs: [config],
+      candidateRecords: [],
+      partyMap: {},
+      partyListRecords: [],
+      concurrency: 1,
+    });
+
+    expect(mockGetElectoratePageHtml).toHaveBeenCalledWith(
+      expect.anything(),
+      config
+    );
+    expect(source.parseRawResults).not.toHaveBeenCalled();
+    expect(payload.electorateResults).toHaveLength(0);
+  });
+
+  test('parses real pages that are not challenge pages', async () => {
+    const config: ElectorateConfig = {
+      electorateName: 'Auckland Central',
+      url: 'https://example.test/electorate-details-01.html',
+    };
+
+    mockGetElectoratePageHtml.mockResolvedValue('<html>real results</html>');
+    mockIsCloudflareChallenge.mockReturnValue(false);
+
+    const source: ElectionSource = {
+      getElectorateConfigs: () => [config],
+      parseRawResults: vi.fn().mockReturnValue({
+        electorateName: 'Auckland Central',
+        candidateVotes: [{ candidate: 'Alice', votes: 1000 }],
+        partyVotes: [{ candidate: 'Red Party', votes: 1000 }],
+        votesCounted: 1000,
+        votePercentageCounted: 0.5,
+      }),
+    };
+
+    const payload = await scrapeCycle({
+      context: {} as BrowserContext,
+      source,
+      configs: [config],
+      candidateRecords: [{ Name: 'Alice', Party: 'Red Party' }],
+      partyMap: { Alice: 'Red Party' },
+      partyListRecords: [],
+      concurrency: 1,
+    });
+
+    expect(source.parseRawResults).toHaveBeenCalledWith(
+      '<html>real results</html>',
+      config
+    );
+    expect(payload.electorateResults).toHaveLength(1);
+    expect(payload.electorateResults[0].electorateName).toBe('Auckland Central');
+  });
+});

--- a/packages/collector/src/scrape-cycle.ts
+++ b/packages/collector/src/scrape-cycle.ts
@@ -16,7 +16,7 @@ import {
   predictWinner,
 } from '@election-night/core/reducers';
 import { log } from './logger.js';
-import { getElectoratePageHtml } from './scraper.js';
+import { getElectoratePageHtml, isCloudflareChallenge } from './scraper.js';
 import { sleep } from './util.js';
 import { collectorConfig } from './config.js';
 import { publishMetrics } from './ws-client.js';
@@ -57,6 +57,9 @@ export async function scrapeCycle(
     const startedAt = performance.now();
     try {
       const html = await getElectoratePageHtml(context, electorateConfig);
+      if (isCloudflareChallenge(html, electorateConfig.url)) {
+        throw new Error('Cloudflare challenge page detected');
+      }
       return { html, config: electorateConfig };
     } catch (reason) {
       const elapsed = ((performance.now() - startedAt) / 1000).toFixed(1);

--- a/packages/collector/src/serve-mock.ts
+++ b/packages/collector/src/serve-mock.ts
@@ -51,7 +51,12 @@ function buildNameToResults(): Map<string, ElectorateResults[]> {
 const resultsMap = buildNameToResults();
 
 function escapeHtml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 function formatVotes(n: number): string {
@@ -145,7 +150,7 @@ function renderPage(results: ElectorateResults): string {
                 <tr><td colspan="3" class="item"></td></tr>
                 ${
                   partyLead
-                    ? `<tr><td>PARTY VOTE LEAD:</td><td class="bold">${escapeHtml(partyLead.candidate)}</td><td class="bold text-right">${(partyLead.votes / totalPartyVotes * 100).toFixed(2)}%</td><td></td></tr>`
+                    ? `<tr><td>PARTY VOTE LEAD:</td><td class="bold">${escapeHtml(partyLead.candidate)}</td><td class="bold text-right">${(totalPartyVotes > 0 ? (partyLead.votes / totalPartyVotes * 100) : 0).toFixed(2)}%</td><td></td></tr>`
                     : ''
                 }
               </tbody>
@@ -321,6 +326,11 @@ const server = http.createServer((req, res) => {
 
   res.writeHead(404);
   res.end('Not found');
+});
+
+server.on('error', (err) => {
+  console.error(`Mock server failed on port ${PORT}:`, err);
+  process.exit(1);
 });
 
 server.listen(PORT, () => {

--- a/packages/collector/src/source-loader.ts
+++ b/packages/collector/src/source-loader.ts
@@ -1,7 +1,36 @@
-import { resolve } from 'path';
+import { isAbsolute, resolve, sep } from 'path';
+import { fileURLToPath } from 'url';
 import type { ElectorateConfig, ElectionSource } from '@election-night/core/types';
 import { NzElectionResultsSource } from '@election-night/core/sources/nz-election-results';
 import { log } from './logger.js';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const REPO_ROOT = resolve(__dirname, '../../..');
+
+function validateSourcePath(sourcePath: string): string {
+  if (isAbsolute(sourcePath)) {
+    throw new Error(
+      `ELECTION_SOURCE_PATH must be a relative path, got absolute path: ${sourcePath}`
+    );
+  }
+  if (sourcePath.includes('..')) {
+    throw new Error(
+      `ELECTION_SOURCE_PATH must not contain parent directory references: ${sourcePath}`
+    );
+  }
+  if (!/\.(ts|js)$/i.test(sourcePath)) {
+    throw new Error(
+      `ELECTION_SOURCE_PATH must point to a .ts or .js file: ${sourcePath}`
+    );
+  }
+  const resolvedPath = resolve(process.cwd(), sourcePath);
+  if (!resolvedPath.startsWith(REPO_ROOT + sep)) {
+    throw new Error(
+      `ELECTION_SOURCE_PATH must resolve inside the repository: ${resolvedPath}`
+    );
+  }
+  return resolvedPath;
+}
 
 export type SourceLoadResult = {
   source: ElectionSource;
@@ -14,12 +43,12 @@ export async function loadSource(
   const sourcePath = process.env.ELECTION_SOURCE_PATH;
 
   if (sourcePath) {
-    const resolvedPath = resolve(process.cwd(), sourcePath);
+    const resolvedPath = validateSourcePath(sourcePath);
     log.info(`Loading custom election source from: ${resolvedPath}`);
     try {
       const mod = await import(resolvedPath);
       const SourceClass = mod.default ?? mod.NzElectionResultsSource;
-      const source = new SourceClass() as ElectionSource;
+      const source = new SourceClass({ electorateNames }) as ElectionSource;
       const configs = source.getElectorateConfigs();
       log.info(`Loaded source with ${configs.length} electorates`);
       return { source, configs };

--- a/packages/collector/src/ws-client.ts
+++ b/packages/collector/src/ws-client.ts
@@ -7,6 +7,8 @@ import { health } from './health.js';
 
 let socket: Socket | null = null;
 const pendingResults: ResultsPayload[] = [];
+const MAX_PENDING_RESULTS = 10;
+let droppedResults = 0;
 
 function flushPending() {
   if (!socket?.connected) return;
@@ -19,7 +21,10 @@ function flushPending() {
 }
 
 export function publishMetrics(events: MetricEvent | MetricEvent[]) {
-  if (!socket?.connected) return;
+  if (!socket?.connected) {
+    log.debug('Socket.io not connected, dropping metrics event');
+    return;
+  }
   socket.emit('metrics', events);
 }
 
@@ -51,8 +56,15 @@ export function connectWs(url: string) {
 
 export function publishResults(payload: ResultsPayload) {
   if (!socket?.connected) {
-    log.debug('Socket.io not connected, queueing results for retry');
+    if (pendingResults.length >= MAX_PENDING_RESULTS) {
+      pendingResults.shift();
+      droppedResults += 1;
+      log.warn(
+        `Socket.io not connected; pending results queue full. Dropped ${droppedResults} result payload(s) so far.`
+      );
+    }
     pendingResults.push(payload);
+    log.debug('Socket.io not connected, queueing results for retry');
     return;
   }
 

--- a/packages/core/src/reducers.test.ts
+++ b/packages/core/src/reducers.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from 'vitest';
+import {
+  calculateLead,
+  predictWinner,
+  calculatePartyVoteWithPercentages,
+} from './reducers.js';
+import type { ElectorateResults } from './types.js';
+
+function makeElectorate(
+  overrides: Partial<ElectorateResults> = {}
+): ElectorateResults {
+  return {
+    electorateName: 'Test',
+    partyVotes: [
+      { candidate: 'Red Party', votes: 4000 },
+      { candidate: 'Blue Party', votes: 3000 },
+    ],
+    candidateVotes: [
+      { candidate: 'Alice', votes: 4000, party: 'Red Party' },
+      { candidate: 'Bob', votes: 3000, party: 'Blue Party' },
+      { candidate: 'Carol', votes: 2000, party: 'Green Party' },
+    ],
+    votesCounted: 9000,
+    votePercentageCounted: 0.9,
+    ...overrides,
+  };
+}
+
+const partyMap: Record<string, string | undefined> = {
+  Alice: 'Red Party',
+  Bob: 'Blue Party',
+  Carol: 'Green Party',
+};
+
+describe('predictWinner', () => {
+  test('returns too-close and zero MoE when no votes have been counted', () => {
+    const r = calculateLead(makeElectorate({ votesCounted: 0 }), partyMap);
+    const predicted = predictWinner(r, 0.95);
+
+    expect(predicted.marginOfError).toBe(0);
+    expect(predicted.leaders.predictionStatus).toBe('too-close');
+  });
+
+  test('returns too-close and zero MoE when percentage counted is zero', () => {
+    const r = calculateLead(
+      makeElectorate({ votesCounted: 1000, votePercentageCounted: 0 }),
+      partyMap
+    );
+    const predicted = predictWinner(r, 0.95);
+
+    expect(predicted.marginOfError).toBe(0);
+    expect(predicted.leaders.predictionStatus).toBe('too-close');
+  });
+
+  test('computes normally for valid partial counts', () => {
+    const r = calculateLead(makeElectorate(), partyMap);
+    const predicted = predictWinner(r, 0.95);
+
+    expect(predicted.marginOfError).toBeGreaterThan(0);
+    expect(predicted.leaders.predictionStatus).not.toBe('too-close');
+  });
+});
+
+describe('calculatePartyVoteWithPercentages', () => {
+  test('returns zero percentages and zero MoE when no votes counted', () => {
+    const r = makeElectorate({ votesCounted: 0, votePercentageCounted: 0 });
+    const withLead = calculateLead(r, partyMap);
+    const predicted = predictWinner(withLead, 0.95);
+    const partyVote = calculatePartyVoteWithPercentages([predicted], 0.95);
+
+    for (const p of partyVote) {
+      expect(p.percentage).toBe(0);
+      expect(p.marginOfError).toBe(0);
+    }
+  });
+
+  test('ignores electorates with zero percentage counted when aggregating totals', () => {
+    const valid = makeElectorate({
+      electorateName: 'Valid',
+      votesCounted: 7000,
+      votePercentageCounted: 0.7,
+      partyVotes: [
+        { candidate: 'Red Party', votes: 4000 },
+        { candidate: 'Blue Party', votes: 3000 },
+      ],
+    });
+    const invalid = makeElectorate({
+      electorateName: 'Invalid',
+      votesCounted: 0,
+      votePercentageCounted: 0,
+      partyVotes: [],
+      candidateVotes: [],
+    });
+
+    const withLead = [
+      predictWinner(calculateLead(valid, partyMap), 0.95),
+      predictWinner(calculateLead(invalid, partyMap), 0.95),
+    ];
+
+    const partyVote = calculatePartyVoteWithPercentages(withLead, 0.95);
+    const red = partyVote.find((p) => p.candidate === 'Red Party');
+
+    expect(red).toBeDefined();
+    expect(red!.marginOfError).toBeGreaterThan(0);
+    expect(red!.percentage).toBeCloseTo(4000 / 7000, 6);
+  });
+});

--- a/packages/core/src/reducers.ts
+++ b/packages/core/src/reducers.ts
@@ -18,6 +18,13 @@ function calculateMarginOfError(
   population: number,
   confidence: number
 ) {
+  if (
+    sample <= 0 ||
+    population <= 0 ||
+    !Number.isFinite(resultAsPercentage)
+  ) {
+    return 0;
+  }
   const zScore = jstat.normal.inv(1 - (1 - confidence) / 2, 0, 1);
   const finitePopulationCorrection = Math.sqrt(
     (population - sample) / (population - 1)
@@ -27,7 +34,7 @@ function calculateMarginOfError(
     Math.sqrt((resultAsPercentage * (1 - resultAsPercentage)) / sample) *
     finitePopulationCorrection;
 
-  return marginOfError;
+  return Number.isFinite(marginOfError) ? marginOfError : 0;
 }
 
 function predictionStatusFromRatio(ratio: number): PredictionStatus {
@@ -79,7 +86,24 @@ function predictWinner(
   confidence: number
 ): ElectorateResults & WithLeaders & WithMarginOfError {
   const votesCounted = results.votesCounted;
-  const totalVotes = votesCounted / results.votePercentageCounted;
+  const votePercentageCounted = results.votePercentageCounted;
+
+  if (
+    votesCounted <= 0 ||
+    votePercentageCounted <= 0 ||
+    !Number.isFinite(votePercentageCounted)
+  ) {
+    return {
+      ...results,
+      marginOfError: 0,
+      leaders: {
+        ...results.leaders,
+        predictionStatus: 'too-close',
+      },
+    };
+  }
+
+  const totalVotes = votesCounted / votePercentageCounted;
   const leadingShare = (results.candidateVotes[0]?.votes ?? 0) / votesCounted;
   const secondShare = (results.candidateVotes[1]?.votes ?? 0) / votesCounted;
   const leadPercent = leadingShare - secondShare;
@@ -103,7 +127,7 @@ function predictWinner(
 
   return {
     ...results,
-    marginOfError,
+    marginOfError: Number.isFinite(marginOfError) ? marginOfError : 0,
     leaders: {
       ...results.leaders,
       predictionStatus: predictionStatusFromRatio(ratio),
@@ -130,10 +154,12 @@ function calculatePartyVote(results: ElectorateResults[]): VotingResults[] {
 
 function aggregateVotesCounted(results: ElectorateResults[]) {
   const votesCounted = results.reduce((prev, x) => prev + x.votesCounted, 0);
-  const totalVotes = results.reduce(
-    (prev, x) => prev + x.votesCounted / x.votePercentageCounted,
-    0
-  );
+  const totalVotes = results.reduce((prev, x) => {
+    const pct = x.votePercentageCounted;
+    return pct > 0 && Number.isFinite(pct)
+      ? prev + x.votesCounted / pct
+      : prev;
+  }, 0);
 
   return { votesCounted, totalVotes };
 }
@@ -144,6 +170,14 @@ function calculatePartyVoteWithPercentages(
 ): (VotingResults & WithPercentages)[] {
   const { votesCounted, totalVotes } = aggregateVotesCounted(results);
   const votes = calculatePartyVote(results);
+
+  if (votesCounted <= 0) {
+    return votes.map((x) => ({
+      ...x,
+      percentage: 0,
+      marginOfError: 0,
+    }));
+  }
 
   return votes.map((x) => ({
     ...x,

--- a/packages/dashboard/server/feed-events.ts
+++ b/packages/dashboard/server/feed-events.ts
@@ -1,0 +1,133 @@
+import type { ElectorateDiff, FeedEvent } from '@election-night/core/types';
+import {
+  computeDiff,
+  diffFacts,
+  determineFeedEventType,
+  type ComparableResult,
+} from '@election-night/core/diff';
+
+/**
+ * Render the short (summary) and long (commentary) copy for one diff.
+ * Both variants are produced together so the facts can never drift
+ * between them.
+ */
+function renderCopy(
+  diff: ElectorateDiff,
+  result: ComparableResult
+): { summary: string; commentary: string } {
+  const l = result.leaders;
+  const name = result.electorateName;
+  const pct = (result.votePercentageCounted * 100).toFixed(0);
+  const marginPct = (l.marginPercent * 100).toFixed(2);
+  const party = (p: string | null | undefined) => p ?? 'Independent';
+  const moePct = (result.marginOfError * 100).toFixed(1);
+  const leader = `${l.leadingCandidate} (${party(l.leadingCandidateParty)})`;
+
+  if (diff.leaderChanged) {
+    const outgoing = `${diff.previousLeaderName} (${party(diff.previousLeaderParty)})`;
+    return {
+      summary: `${name}: ${leader} took the lead from ${outgoing} — leads by ${marginPct}%.`,
+      commentary: `${leader} has taken the lead from ${outgoing} in ${name}. The lead is ${marginPct}% with ${pct}% of votes counted.`,
+    };
+  }
+
+  const facts = diffFacts(diff);
+  if (facts.countCompleted) {
+    return {
+      summary: `${name}: ${leader} is the likely winner — ${marginPct}% lead at 100% counted.`,
+      commentary: `${leader} is the likely winner in ${name} with all ordinary votes counted.`,
+    };
+  }
+
+  if (diff.predictionStatusChanged && facts.predictionCalled) {
+    return {
+      summary: `${name}: ${leader} is the likely winner — ${marginPct}% lead exceeds ±${moePct}% MoE, making this a confident prediction at ${pct}% counted.`,
+      commentary: `${leader} is the likely winner in ${name}. The ${marginPct}% lead exceeds the ±${moePct}% margin of error, making this a confident prediction at ${pct}% counted.`,
+    };
+  }
+
+  if (diff.predictionStatusChanged && l.predictionStatus === 'leaning') {
+    return {
+      summary: `${name}: ${leader} is ahead by ${marginPct}% — but the ±${moePct}% MoE means the race is still too close to call at ${pct}% counted.`,
+      commentary: `${leader} is ahead in ${name} with ${marginPct}% of the vote. But a ±${moePct}% margin of error means the race is still too close to call at ${pct}% counted.`,
+    };
+  }
+
+  if (diff.previousMargin !== null && diff.previousMarginPercent !== null) {
+    const marginDelta = l.margin - diff.previousMargin;
+    if (marginDelta > 0) {
+      const widenedPct = (
+        (l.marginPercent - diff.previousMarginPercent) *
+        100
+      ).toFixed(2);
+      return {
+        summary: `${name}: ${leader} extended their lead by ${widenedPct}% to ${marginPct}% at ${pct}% counted.`,
+        commentary: `${leader} extended their lead by ${widenedPct}% to ${marginPct}% in ${name} at ${pct}% counted.`,
+      };
+    }
+    if (marginDelta < 0) {
+      const narrowedPct = (
+        (diff.previousMarginPercent - l.marginPercent) *
+        100
+      ).toFixed(2);
+      return {
+        summary: `${name}: ${leader} leads by ${marginPct}% at ${pct}% counted — the gap narrowed by ${narrowedPct}%.`,
+        commentary: `${leader} leads in ${name} by ${marginPct}% at ${pct}% counted — the gap narrowed by ${narrowedPct}%.`,
+      };
+    }
+  }
+
+  const second = `${l.secondCandidate} (${party(l.secondCandidateParty)})`;
+  return {
+    summary: `${name}: ${leader} leads ${second} by ${marginPct}% at ${pct}% counted.`,
+    commentary: `${leader} leads ${second} by ${marginPct}% in ${name} at ${pct}% counted.`,
+  };
+}
+
+/**
+ * Compare a new payload against the previous one and generate feed events
+ * for every electorate where something interesting happened.
+ *
+ * The first scrape of an electorate just establishes a baseline and does
+ * not produce a feed event, matching the core diff contract.
+ */
+export function buildFeedEvents(
+  previous: ComparableResult[],
+  current: ComparableResult[]
+): FeedEvent[] {
+  const events: FeedEvent[] = [];
+  const prevMap = new Map(previous.map((r) => [r.electorateName, r]));
+
+  for (const result of current) {
+    const diff = computeDiff(prevMap.get(result.electorateName), result);
+    const facts = diffFacts(diff);
+
+    // First scrape just establishes a baseline; no feed events.
+    if (facts.isFirstResult) continue;
+
+    if (
+      !facts.votesChanged &&
+      !diff.predictionStatusChanged &&
+      !diff.leaderChanged &&
+      !facts.countCompleted
+    )
+      continue;
+
+    const { summary, commentary } = renderCopy(diff, result);
+    events.push({
+      id: `${result.electorateName}-${diff.currentVotesCounted}-${Math.round(
+        (diff.currentMargin ?? 0) * 100
+      )}-${diff.currentPredictionStatus ?? 'none'}`,
+      timestamp: Date.now(),
+      type: determineFeedEventType(diff),
+      electorateName: result.electorateName,
+      predictionStatus: result.leaders.predictionStatus,
+      marginOfError: result.marginOfError,
+      summary,
+      commentary,
+      diff,
+    });
+  }
+
+  return events;
+}

--- a/packages/dashboard/server/feed.ts
+++ b/packages/dashboard/server/feed.ts
@@ -1,15 +1,11 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { dirname } from 'path';
-import type { ElectorateDiff, FeedEvent } from '@election-night/core/types';
-import {
-  computeDiff,
-  diffFacts,
-  determineFeedEventType,
-  type ComparableResult,
-} from '@election-night/core/diff';
+import type { FeedEvent } from '@election-night/core/types';
 import { dashboardServerConfig } from './config.js';
 import { feedEventsTotal } from './metrics.js';
 import { log } from './logger.js';
+
+export { buildFeedEvents } from './feed-events.js';
 
 const FEED_CACHE_PATH = dashboardServerConfig.feedCachePath;
 const MAX_FEED_EVENTS = dashboardServerConfig.maxFeedEvents;
@@ -47,126 +43,6 @@ function saveFeedEvents(events: FeedEvent[]) {
   } catch (err) {
     log.error('Failed to save feed events:', err);
   }
-}
-
-/**
- * Render the short (summary) and long (commentary) copy for one diff.
- * Both variants are produced together so the facts can never drift
- * between them.
- */
-function renderCopy(
-  diff: ElectorateDiff,
-  result: ComparableResult
-): { summary: string; commentary: string } {
-  const l = result.leaders;
-  const name = result.electorateName;
-  const pct = (result.votePercentageCounted * 100).toFixed(0);
-  const marginPct = (l.marginPercent * 100).toFixed(2);
-  const party = (p: string | null | undefined) => p ?? 'Independent';
-  const moePct = (result.marginOfError * 100).toFixed(1);
-  const leader = `${l.leadingCandidate} (${party(l.leadingCandidateParty)})`;
-
-  if (diff.leaderChanged) {
-    const outgoing = `${diff.previousLeaderName} (${party(diff.previousLeaderParty)})`;
-    return {
-      summary: `${name}: ${leader} took the lead from ${outgoing} — leads by ${marginPct}%.`,
-      commentary: `${leader} has taken the lead from ${outgoing} in ${name}. The lead is ${marginPct}% with ${pct}% of votes counted.`,
-    };
-  }
-
-  const facts = diffFacts(diff);
-  if (facts.countCompleted) {
-    return {
-      summary: `${name}: ${leader} is the likely winner — ${marginPct}% lead at 100% counted.`,
-      commentary: `${leader} is the likely winner in ${name} with all ordinary votes counted.`,
-    };
-  }
-
-  if (diff.predictionStatusChanged && facts.predictionCalled) {
-    return {
-      summary: `${name}: ${leader} is the likely winner — ${marginPct}% lead exceeds ±${moePct}% MoE, making this a confident prediction at ${pct}% counted.`,
-      commentary: `${leader} is the likely winner in ${name}. The ${marginPct}% lead exceeds the ±${moePct}% margin of error, making this a confident prediction at ${pct}% counted.`,
-    };
-  }
-
-  if (diff.predictionStatusChanged && l.predictionStatus === 'leaning') {
-    return {
-      summary: `${name}: ${leader} is ahead by ${marginPct}% — but the ±${moePct}% MoE means the race is still too close to call at ${pct}% counted.`,
-      commentary: `${leader} is ahead in ${name} with ${marginPct}% of the vote. But a ±${moePct}% margin of error means the race is still too close to call at ${pct}% counted.`,
-    };
-  }
-
-  if (diff.previousMargin !== null && diff.previousMarginPercent !== null) {
-    const marginDelta = l.margin - diff.previousMargin;
-    if (marginDelta > 0) {
-      const widenedPct = (
-        (l.marginPercent - diff.previousMarginPercent) *
-        100
-      ).toFixed(2);
-      return {
-        summary: `${name}: ${leader} extended their lead by ${widenedPct}% to ${marginPct}% at ${pct}% counted.`,
-        commentary: `${leader} extended their lead by ${widenedPct}% to ${marginPct}% in ${name} at ${pct}% counted.`,
-      };
-    }
-    if (marginDelta < 0) {
-      const narrowedPct = (
-        (diff.previousMarginPercent - l.marginPercent) *
-        100
-      ).toFixed(2);
-      return {
-        summary: `${name}: ${leader} leads by ${marginPct}% at ${pct}% counted — the gap narrowed by ${narrowedPct}%.`,
-        commentary: `${leader} leads in ${name} by ${marginPct}% at ${pct}% counted — the gap narrowed by ${narrowedPct}%.`,
-      };
-    }
-  }
-
-  const second = `${l.secondCandidate} (${party(l.secondCandidateParty)})`;
-  return {
-    summary: `${name}: ${leader} leads ${second} by ${marginPct}% at ${pct}% counted.`,
-    commentary: `${leader} leads ${second} by ${marginPct}% in ${name} at ${pct}% counted.`,
-  };
-}
-
-/**
- * Compare a new payload against the previous one and generate feed events
- * for every electorate where something interesting happened.
- */
-export function buildFeedEvents(
-  previous: ComparableResult[],
-  current: ComparableResult[]
-): FeedEvent[] {
-  const events: FeedEvent[] = [];
-  const prevMap = new Map(previous.map((r) => [r.electorateName, r]));
-
-  for (const result of current) {
-    const diff = computeDiff(prevMap.get(result.electorateName), result);
-    const facts = diffFacts(diff);
-
-    if (
-      !facts.votesChanged &&
-      !diff.predictionStatusChanged &&
-      !diff.leaderChanged &&
-      !facts.countCompleted
-    )
-      continue;
-
-    const { summary, commentary } = renderCopy(diff, result);
-    events.push({
-      id: `${result.electorateName}-${diff.currentVotesCounted}-${Math.round(
-        (diff.currentMargin ?? 0) * 100
-      )}-${diff.currentPredictionStatus ?? 'none'}`,
-      timestamp: Date.now(),
-      type: determineFeedEventType(diff),
-      electorateName: result.electorateName,
-      predictionStatus: result.leaders.predictionStatus,
-      marginOfError: result.marginOfError,
-      summary,
-      commentary,
-      diff,
-    });
-  }
-
-  return events;
 }
 
 /**

--- a/packages/dashboard/server/history-upstream.ts
+++ b/packages/dashboard/server/history-upstream.ts
@@ -24,6 +24,7 @@ export interface HistorySource {
   snapshotMetas(): Promise<SnapshotMeta[]>;
   electorateHistory(name: string): Promise<ElectorateHistoryPoint[]>;
   partyVoteHistory(): Promise<PartyVoteHistoryPoint[]>;
+  clearCache(): void;
 }
 
 interface CacheEntry {
@@ -77,5 +78,6 @@ export function createHistorySource(options: {
     electorateHistory: (name) =>
       fetchJson(`/history/electorate/${encodeURIComponent(name)}`),
     partyVoteHistory: () => fetchJson('/history/party-votes'),
+    clearCache: () => cache.clear(),
   };
 }

--- a/packages/dashboard/server/index.ts
+++ b/packages/dashboard/server/index.ts
@@ -25,6 +25,7 @@ import {
   loadFeedEvents,
   resetFeedState,
 } from './feed.js';
+import { withMutex, Mutex } from './mutex.js';
 import { log } from './logger.js';
 
 const {
@@ -35,6 +36,7 @@ const {
 } = dashboardServerConfig;
 
 let latestResults: ResultsPayload | null = null;
+const feedMutex = new Mutex();
 
 function loadCachedResults() {
   if (existsSync(CACHE_PATH)) {
@@ -75,9 +77,12 @@ const server = createServer(
         res.end(JSON.stringify({ error: 'invalid or missing x-clear-token' }));
         return;
       }
-      latestResults = null;
-      resetFeedState();
-      io.emit('clear');
+      await withMutex(feedMutex, async () => {
+        latestResults = null;
+        resetFeedState();
+        historySource.clearCache();
+        io.emit('clear');
+      });
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ status: 'ok', message: 'Feed cleared' }));
       return;
@@ -124,23 +129,25 @@ io.on('connection', (socket) => {
   }
 
   socket.on('results_update', (payload: ResultsPayload) => {
-    const previousResults = latestResults?.electorateResults ?? [];
-    latestResults = payload;
-    lastScrapeTimestampSeconds.set(Date.now() / 1000);
-    log.info('Received results update, broadcasting...');
-    socket.broadcast.emit('results_update', payload);
+    withMutex(feedMutex, async () => {
+      const previousResults = latestResults?.electorateResults ?? [];
+      latestResults = payload;
+      lastScrapeTimestampSeconds.set(Date.now() / 1000);
+      log.info('Received results update, broadcasting...');
+      socket.broadcast.emit('results_update', payload);
 
-    const rawEvents = buildFeedEvents(
-      previousResults,
-      payload.electorateResults
-    );
-    if (rawEvents.length === 0) return;
+      const rawEvents = buildFeedEvents(
+        previousResults,
+        payload.electorateResults
+      );
+      if (rawEvents.length === 0) return;
 
-    const newEvents = addFeedEvents(rawEvents);
-    if (newEvents.length > 0) {
-      log.info(`Generated ${newEvents.length} feed events`);
-      io.emit('feed_update', newEvents);
-    }
+      const newEvents = addFeedEvents(rawEvents);
+      if (newEvents.length > 0) {
+        log.info(`Generated ${newEvents.length} feed events`);
+        io.emit('feed_update', newEvents);
+      }
+    }).catch((err) => log.error('results_update handler failed:', err));
   });
 
   socket.on('disconnect', () => {

--- a/packages/dashboard/server/mutex.ts
+++ b/packages/dashboard/server/mutex.ts
@@ -1,0 +1,33 @@
+/**
+ * A simple async mutex: one task holds the lock at a time; later tasks wait
+ * in FIFO order. Used to serialize operations that touch shared module state
+ * (latestResults and feedEvents).
+ */
+export class Mutex {
+  private promise: Promise<void> = Promise.resolve();
+
+  async acquire(): Promise<() => void> {
+    const previous = this.promise;
+    let release: () => void;
+    this.promise = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    return release!;
+  }
+}
+
+/**
+ * Convenience helper that runs `fn` while holding `mutex`.
+ */
+export async function withMutex<T>(
+  mutex: Mutex,
+  fn: () => Promise<T> | T
+): Promise<T> {
+  const release = await mutex.acquire();
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}

--- a/packages/dashboard/server/ready-check.ts
+++ b/packages/dashboard/server/ready-check.ts
@@ -1,0 +1,25 @@
+/**
+ * Pure ready-state evaluation used by the /ready HTTP handler.
+ *
+ * Readiness is based on history upstream reachability. An empty feed event
+ * list does not make the server unready, but the last scrape timestamp is
+ * still reported in the checks payload when available.
+ */
+export function evaluateReady(
+  historyReachable: boolean,
+  lastScrape: number | 'none'
+): { ready: boolean; checks: Record<string, string | number> } {
+  const checks: Record<string, string | number> = {};
+  let ready = true;
+
+  if (historyReachable) {
+    checks.history = 'upstream';
+  } else {
+    checks.history = 'error';
+    ready = false;
+  }
+
+  checks.lastScrape = lastScrape;
+
+  return { ready, checks };
+}

--- a/packages/dashboard/server/static.ts
+++ b/packages/dashboard/server/static.ts
@@ -4,6 +4,7 @@ import type { IncomingMessage, ServerResponse } from 'http';
 import { register, metricsResponse } from './metrics.js';
 import { dashboardServerConfig } from './config.js';
 import type { HistorySource } from './history-upstream.js';
+import { evaluateReady } from './ready-check.js';
 import { log } from './logger.js';
 
 const DIST_DIR = dashboardServerConfig.distDir;
@@ -50,30 +51,27 @@ export function serveHealth(_req: IncomingMessage, res: ServerResponse) {
   res.end(JSON.stringify({ status: 'ok' }));
 }
 
+async function isHistoryReachable(source: HistorySource): Promise<boolean> {
+  try {
+    await source.snapshotMetas();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export async function serveReady(
   _req: IncomingMessage,
   res: ServerResponse,
   historySource: HistorySource,
   feedEvents: { timestamp: number }[]
 ) {
-  const checks: Record<string, string | boolean | number> = {};
-  let ready = true;
-
-  try {
-    await historySource.snapshotMetas();
-    checks.history = 'upstream';
-  } catch {
-    checks.history = 'error';
-    ready = false;
-  }
+  const historyReachable = await isHistoryReachable(historySource);
 
   const lastEvent = feedEvents[feedEvents.length - 1];
-  if (lastEvent) {
-    checks.lastScrape = lastEvent.timestamp;
-  } else {
-    checks.lastScrape = 'none';
-    ready = false;
-  }
+  const lastScrape = lastEvent ? lastEvent.timestamp : 'none';
+
+  const { ready, checks } = evaluateReady(historyReachable, lastScrape);
 
   res.writeHead(ready ? 200 : 503, { 'Content-Type': 'application/json' });
   res.end(JSON.stringify({ ready, checks }));

--- a/packages/dashboard/src/components/BottomSheet.test.tsx
+++ b/packages/dashboard/src/components/BottomSheet.test.tsx
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+import { describe, expect, test, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import BottomSheet from './BottomSheet.js';
+
+describe('BottomSheet', () => {
+  test('renders dialog with accessibility attributes when open', () => {
+    render(
+      <BottomSheet open onClose={vi.fn()} title="Seat details">
+        <p>Content</p>
+      </BottomSheet>
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby');
+
+    const title = screen.getByText('Seat details');
+    expect(title.id).toBe(dialog.getAttribute('aria-labelledby'));
+  });
+
+  test('does not render when closed', () => {
+    render(
+      <BottomSheet open={false} onClose={vi.fn()}>
+        <p>Content</p>
+      </BottomSheet>
+    );
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/packages/dashboard/src/components/BottomSheet.tsx
+++ b/packages/dashboard/src/components/BottomSheet.tsx
@@ -1,13 +1,16 @@
-import { useEffect, type ReactNode } from 'react';
+import { useEffect, useId, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 
 interface BottomSheetProps {
   open: boolean;
   onClose: () => void;
   children: ReactNode;
+  title?: string;
 }
 
-export default function BottomSheet({ open, onClose, children }: BottomSheetProps) {
+export default function BottomSheet({ open, onClose, children, title }: BottomSheetProps) {
+  const titleId = useId();
+
   useEffect(() => {
     if (!open) return;
     const prev = document.body.style.overflow;
@@ -33,6 +36,9 @@ export default function BottomSheet({ open, onClose, children }: BottomSheetProp
         onClick={onClose}
       />
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
         className="absolute bottom-0 left-0 right-0 bg-background border-t border-border max-h-[70dvh] overflow-y-auto animate-slide-up overscroll-y-contain"
         style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
         onClick={(e) => e.stopPropagation()}
@@ -41,6 +47,11 @@ export default function BottomSheet({ open, onClose, children }: BottomSheetProp
           <div className="w-10 border-t-2 border-foreground/40" />
         </div>
         <div className="p-4 pt-2">
+          {title && (
+            <h2 id={titleId} className="font-display text-base font-bold tracking-tight mb-2">
+              {title}
+            </h2>
+          )}
           {children}
         </div>
       </div>

--- a/packages/dashboard/src/components/ElectorateMap.tsx
+++ b/packages/dashboard/src/components/ElectorateMap.tsx
@@ -1,11 +1,14 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { MapContainer, TileLayer, GeoJSON, useMap } from 'react-leaflet';
 import { useNavigate } from 'react-router-dom';
 import L from 'leaflet';
 import { partyColors } from '../lib/constants.js';
 import 'leaflet/dist/leaflet.css';
 
-const defaultIconPrototype = L.Icon.Default.prototype as unknown as Record<string, unknown>;
+const defaultIconPrototype = L.Icon.Default.prototype as unknown as Record<
+  string,
+  unknown
+>;
 delete defaultIconPrototype._getIconUrl;
 L.Icon.Default.mergeOptions({
   iconRetinaUrl:
@@ -17,6 +20,7 @@ import type {
   ElectorateResults,
   WithLeaders,
   WithMarginOfError,
+  VotingResults,
 } from '@election-night/core/types';
 
 type ElectorateResult = ElectorateResults & WithLeaders & WithMarginOfError;
@@ -48,6 +52,48 @@ type GeoFeatureCollection = GeoJSON.FeatureCollection<
   { name: string }
 >;
 
+function isGeoFeatureCollection(data: unknown): data is GeoFeatureCollection {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'features' in data &&
+    Array.isArray((data as GeoFeatureCollection).features)
+  );
+}
+
+function leadingPartyVote(
+  partyVotes: VotingResults[]
+): VotingResults | undefined {
+  if (partyVotes.length === 0) return undefined;
+  let top = partyVotes[0];
+  for (let i = 1; i < partyVotes.length; i++) {
+    if (partyVotes[i].votes > top.votes) top = partyVotes[i];
+  }
+  return top;
+}
+
+function getCandidateOpacity(result: ElectorateResult): number {
+  const moe = result.marginOfError;
+  const marginPercent = result.leaders.marginPercent;
+  if (!Number.isFinite(moe) || moe <= 0) return 0.2;
+  const ratio = marginPercent / moe;
+  if (ratio >= 2) return 0.8;
+  if (ratio <= 1) return 0.2;
+  return 0.2 + (ratio - 1) * 0.6;
+}
+
+function getPartyOpacity(
+  leading: VotingResults | undefined,
+  votesCounted: number
+): number {
+  if (!leading || votesCounted <= 0) return 0.15;
+  const share = leading.votes / votesCounted;
+  if (!Number.isFinite(share)) return 0.15;
+  if (share >= 0.5) return 0.8;
+  if (share <= 0.2) return 0.2;
+  return 0.2 + ((share - 0.2) / 0.3) * 0.6;
+}
+
 function MapUpdater({
   selectedName,
   geoData,
@@ -56,6 +102,7 @@ function MapUpdater({
   geoData: GeoFeatureCollection | null;
 }) {
   const map = useMap();
+  const rafRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (selectedName && geoData) {
@@ -64,17 +111,23 @@ function MapUpdater({
       );
       if (feature) {
         const layer = L.geoJSON(feature);
-        requestAnimationFrame(() => {
+        rafRef.current = requestAnimationFrame(() => {
           map.invalidateSize();
           map.fitBounds(layer.getBounds(), { padding: [30, 30] });
         });
       }
     } else if (geoData) {
-      requestAnimationFrame(() => {
+      rafRef.current = requestAnimationFrame(() => {
         map.invalidateSize();
         map.setView([-41.5, 173.5], 5.5);
       });
     }
+
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+      }
+    };
   }, [selectedName, geoData, map]);
 
   return null;
@@ -87,48 +140,68 @@ export default function ElectorateMap({
   showPartyVote,
 }: ElectorateMapProps) {
   const [geoData, setGeoData] = useState<GeoFeatureCollection | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate();
 
   const geoKey = showMaori ? 'maori' : 'general';
 
-  const getLeadingParty = (result: ElectorateResult) =>
-    [...result.partyVotes].sort((a, b) => b.votes - a.votes)[0];
+  const lookup = useMemo(() => {
+    const map = new Map<
+      string,
+      {
+        color: string;
+        opacity: number;
+      }
+    >();
+    for (const e of electorates) {
+      if (showPartyVote) {
+        const leading = leadingPartyVote(e.partyVotes);
+        map.set(e.electorateName, {
+          color: partyColors[leading?.candidate ?? ''] || '#9ca3af',
+          opacity: getPartyOpacity(leading, e.votesCounted),
+        });
+      } else {
+        map.set(e.electorateName, {
+          color:
+            partyColors[e.leaders.leadingCandidateParty ?? ''] || '#9ca3af',
+          opacity: getCandidateOpacity(e),
+        });
+      }
+    }
+    return map;
+  }, [electorates, showPartyVote]);
 
   useEffect(() => {
     setGeoData(null);
-    fetch(GEO_FILES[geoKey])
-      .then((res) => res.json())
-      .then((data) => setGeoData(data as GeoFeatureCollection));
+    setError(null);
+    const controller = new AbortController();
+
+    fetch(GEO_FILES[geoKey], { signal: controller.signal })
+      .then(async (res) => {
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+        const data = (await res.json()) as unknown;
+        if (!isGeoFeatureCollection(data)) {
+          throw new Error('Invalid GeoJSON payload');
+        }
+        setGeoData(data);
+      })
+      .catch((err) => {
+        if (err instanceof Error && err.name === 'AbortError') return;
+        setError(err instanceof Error ? err.message : 'Failed to load map');
+      });
+
+    return () => controller.abort();
   }, [geoKey]);
 
-  const resultMap = new Map(electorates.map((e) => [e.electorateName, e]));
-
-  const getColor = (name: string) => {
-    const result = resultMap.get(name);
-    if (!result) return '#e5e7eb';
-    if (showPartyVote) {
-      const leading = getLeadingParty(result);
-      return partyColors[leading?.candidate ?? ''] || '#9ca3af';
-    }
-    return partyColors[result.leaders.leadingCandidateParty ?? ''] || '#9ca3af';
-  };
-
-  const getOpacity = (name: string) => {
-    const result = resultMap.get(name);
-    if (!result) return 0.15;
-    if (showPartyVote) {
-      const leading = getLeadingParty(result);
-      if (!leading) return 0.15;
-      const share = leading.votes / result.votesCounted;
-      if (share >= 0.5) return 0.8;
-      if (share <= 0.2) return 0.2;
-      return 0.2 + ((share - 0.2) / 0.3) * 0.6;
-    }
-    const ratio = result.leaders.marginPercent / result.marginOfError;
-    if (ratio >= 2) return 0.8;
-    if (ratio <= 1) return 0.2;
-    return 0.2 + (ratio - 1) * 0.6;
-  };
+  if (error) {
+    return (
+      <div className="flex items-center justify-center h-[300px] sm:h-[600px] border bg-muted/20">
+        <p className="text-muted-foreground text-sm">Map error: {error}</p>
+      </div>
+    );
+  }
 
   if (!geoData) {
     return (
@@ -152,17 +225,18 @@ export default function ElectorateMap({
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
       />
       <GeoJSON
-        key={`${geoKey}-${showPartyVote ? 'party' : 'candidate'}-${electorates.map((e) => showPartyVote ? (getLeadingParty(e)?.candidate ?? '') : (e.leaders.leadingCandidateParty ?? '')).join(',')}`}
+        key={`${geoKey}-${showPartyVote ? 'party' : 'candidate'}`}
         data={geoData}
         style={(feature) => {
           const name = feature?.properties?.name;
           const isSelected = name === selectedName;
+          const style = name ? lookup.get(name) : undefined;
           return {
-            fillColor: getColor(name),
+            fillColor: style?.color ?? '#e5e7eb',
             weight: isSelected ? 3 : 1,
             opacity: 1,
             color: isSelected ? '#000' : '#fff',
-            fillOpacity: getOpacity(name),
+            fillOpacity: style?.opacity ?? 0.15,
           };
         }}
         onEachFeature={(feature, layer) => {

--- a/packages/dashboard/src/components/ElectorateRacesView.test.tsx
+++ b/packages/dashboard/src/components/ElectorateRacesView.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { describe, expect, test, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type * as ReactRouter from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
+import { ElectorateRacesView } from './ElectorateRacesView.js';
+import type { ElectorateResults, WithLeaders, WithMarginOfError } from '@election-night/core/types';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof ReactRouter>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const baseElectorate = {
+  electorateName: 'Auckland Central',
+  candidateVotes: [],
+  partyVotes: [],
+  votesCounted: 1000,
+  votePercentageCounted: 0.5,
+  marginOfError: 0.02,
+  leaders: {
+    leadingCandidate: 'SMITH, John',
+    leadingCandidateParty: 'National Party',
+    secondCandidate: 'JONES, Mary',
+    secondCandidateParty: 'Labour Party',
+    margin: 1000,
+    marginPercent: 0.04,
+    predictionStatus: 'leaning',
+  },
+} as ElectorateResults & WithLeaders & WithMarginOfError;
+
+describe('ElectorateRacesView', () => {
+  test('table rows are keyboard accessible', () => {
+    render(
+      <BrowserRouter>
+        <ElectorateRacesView electorates={[baseElectorate]} />
+      </BrowserRouter>
+    );
+
+    const row = screen.getByRole('button', { name: /View details for Auckland Central/i });
+    expect(row).toHaveAttribute('tabIndex', '0');
+
+    fireEvent.keyDown(row, { key: 'Enter' });
+    expect(mockNavigate).toHaveBeenCalledWith('/electorates/Auckland%20Central');
+
+    mockNavigate.mockClear();
+    fireEvent.keyDown(row, { key: ' ' });
+    expect(mockNavigate).toHaveBeenCalledWith('/electorates/Auckland%20Central');
+  });
+});

--- a/packages/dashboard/src/components/ElectorateRacesView.tsx
+++ b/packages/dashboard/src/components/ElectorateRacesView.tsx
@@ -72,13 +72,24 @@ export function ElectorateRacesView({
               return (
                 <tr
                   key={er.electorateName}
+                  tabIndex={0}
+                  role="button"
+                  aria-label={`View details for ${er.electorateName}`}
                   onClick={() =>
                     navigate(
                       `/electorates/${encodeURIComponent(er.electorateName)}`
                     )
                   }
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      navigate(
+                        `/electorates/${encodeURIComponent(er.electorateName)}`
+                      );
+                    }
+                  }}
                   className={cn(
-                    'border-b last:border-0 transition-colors hover:bg-muted/20 cursor-pointer',
+                    'border-b last:border-0 transition-colors hover:bg-muted/20 cursor-pointer focus:outline-none focus:ring-2 focus:ring-ring/25 focus:bg-muted/20',
                     'opacity-0 animate-fade-in-up'
                   )}
                   style={{ animationDelay: `${i * 0.03}s` }}

--- a/packages/dashboard/src/components/ElectorateResultsTable.tsx
+++ b/packages/dashboard/src/components/ElectorateResultsTable.tsx
@@ -2,12 +2,19 @@ import { cn } from '../lib/utils.js';
 import { partyColors } from '../lib/constants.js';
 import type {
   ElectorateResults,
+  VotingResults,
   WithLeaders,
   WithMarginOfError,
   WithParty,
 } from '@election-night/core/types';
 
 type ElectorateResult = ElectorateResults & WithLeaders & WithMarginOfError;
+
+function hasParty(
+  v: VotingResults | (VotingResults & WithParty)
+): v is VotingResults & WithParty {
+  return 'party' in v;
+}
 
 export function ElectorateResultsTable({
   result,
@@ -82,12 +89,11 @@ export function ElectorateResultsTable({
                           className="w-2 h-2 flex-shrink-0 ring-1 ring-foreground/15"
                           style={{
                             backgroundColor:
-                              partyColors[
-                                (c as typeof c & WithParty).party ?? ''
-                              ] || '#666',
+                              partyColors[hasParty(c) ? (c.party ?? '') : ''] ||
+                              '#666',
                           }}
                         />
-                        {(c as typeof c & WithParty).party ?? 'Independent'}
+                        {hasParty(c) ? (c.party ?? 'Independent') : 'Independent'}
                       </div>
                     </td>
                   </>

--- a/packages/dashboard/src/components/ElectorateSearch.test.tsx
+++ b/packages/dashboard/src/components/ElectorateSearch.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type * as ReactRouter from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
+import { ElectorateSearch } from './ElectorateSearch.js';
+
+const names = ['Auckland Central', 'Banks Peninsula', 'Bay of Plenty'];
+
+const mockedNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof ReactRouter>('react-router-dom');
+  return { ...actual, useNavigate: () => mockedNavigate };
+});
+
+describe('ElectorateSearch', () => {
+  beforeEach(() => {
+    mockedNavigate.mockReset();
+  });
+
+  test('renders a combobox with a hidden label', () => {
+    render(
+      <BrowserRouter>
+        <ElectorateSearch names={names} />
+      </BrowserRouter>
+    );
+
+    const input = screen.getByRole('combobox');
+    expect(input).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByText('Search electorate')).toBeInTheDocument();
+  });
+
+  test('opens listbox and navigates with keyboard', async () => {
+    render(
+      <BrowserRouter>
+        <ElectorateSearch names={names} />
+      </BrowserRouter>
+    );
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'auck' } });
+
+    await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument());
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(1);
+    expect(options[0]).toHaveTextContent('Auckland Central');
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    expect(options[0]).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(mockedNavigate).toHaveBeenCalledWith('/electorates/Auckland%20Central');
+  });
+
+  test('closes listbox on Escape', async () => {
+    render(
+      <BrowserRouter>
+        <ElectorateSearch names={names} />
+      </BrowserRouter>
+    );
+
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    await waitFor(() => expect(screen.getByRole('listbox')).toBeInTheDocument());
+
+    fireEvent.keyDown(input, { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+  });
+});

--- a/packages/dashboard/src/components/ElectorateSearch.tsx
+++ b/packages/dashboard/src/components/ElectorateSearch.tsx
@@ -1,42 +1,120 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { cn } from '../lib/utils.js';
 
 export function ElectorateSearch({ names }: { names: string[] }) {
   const [query, setQuery] = useState('');
   const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
   const inputRef = useRef<HTMLInputElement>(null);
+  const listId = useRef(`electorate-search-list-${Math.random().toString(36).slice(2)}`).current;
+  const timeoutRef = useRef<number | null>(null);
   const navigate = useNavigate();
 
   const filtered = query
     ? names.filter((n) => n.toLowerCase().includes(query.toLowerCase()))
     : names;
 
+  useEffect(() => {
+    return () => {
+      clearTimeout(timeoutRef.current ?? undefined);
+    };
+  }, []);
+
+  const close = () => {
+    setOpen(false);
+    setActiveIndex(-1);
+  };
+
+  const selectName = (name: string) => {
+    navigate(`/electorates/${encodeURIComponent(name)}`);
+    close();
+    setQuery('');
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!open) {
+      if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+        setOpen(true);
+      }
+      return;
+    }
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIndex((prev) => {
+        const next = prev + 1;
+        return next >= filtered.length ? 0 : next;
+      });
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex((prev) => {
+        const next = prev - 1;
+        return next < 0 ? filtered.length - 1 : next;
+      });
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const name = filtered[activeIndex];
+      if (name) {
+        selectName(name);
+      }
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      close();
+    }
+  };
+
+  const activeId =
+    open && activeIndex >= 0 && filtered[activeIndex]
+      ? `${listId}-option-${activeIndex}`
+      : undefined;
+
   return (
     <div className="relative w-full sm:w-auto text-sm">
+      <label className="sr-only" htmlFor="electorate-search-input">
+        Search electorate
+      </label>
       <input
+        id="electorate-search-input"
         ref={inputRef}
         type="text"
+        role="combobox"
+        aria-autocomplete="list"
+        aria-controls={open ? listId : undefined}
+        aria-expanded={open && filtered.length > 0}
+        aria-activedescendant={activeId}
         placeholder="Search electorate…"
         value={query}
         onChange={(e) => {
           setQuery(e.target.value);
           setOpen(true);
+          setActiveIndex(-1);
         }}
         onFocus={() => setOpen(true)}
-        onBlur={() => setTimeout(() => setOpen(false), 200)}
+        onBlur={() => {
+          timeoutRef.current = setTimeout(() => close(), 200);
+        }}
+        onKeyDown={handleKeyDown}
         className="w-full sm:w-56 px-3 py-2 sm:py-1.5 border bg-background font-label text-sm outline-none focus:ring-2 focus:ring-ring/25 transition-shadow"
       />
       {open && filtered.length > 0 && (
-        <ul className="absolute top-full left-0 right-0 mt-1 bg-popover border max-h-64 overflow-y-auto z-50 animate-fade-in">
-          {filtered.map((name) => (
+        <ul
+          id={listId}
+          role="listbox"
+          className="absolute top-full left-0 right-0 mt-1 bg-popover border max-h-64 overflow-y-auto z-50 animate-fade-in"
+        >
+          {filtered.map((name, i) => (
             <li
               key={name}
-              onMouseDown={() => {
-                navigate(`/electorates/${encodeURIComponent(name)}`);
-                setOpen(false);
-                setQuery('');
-              }}
-              className="px-3 py-2 sm:py-1.5 cursor-pointer hover:bg-muted/40 border-b last:border-0 transition-colors font-label text-sm"
+              id={`${listId}-option-${i}`}
+              role="option"
+              aria-selected={i === activeIndex}
+              onMouseDown={() => selectName(name)}
+              onMouseEnter={() => setActiveIndex(i)}
+              className={cn(
+                'px-3 py-2 sm:py-1.5 cursor-pointer border-b last:border-0 transition-colors font-label text-sm',
+                i === activeIndex ? 'bg-muted' : 'hover:bg-muted/40'
+              )}
             >
               {name}
             </li>

--- a/packages/dashboard/src/components/FeedSidebar.tsx
+++ b/packages/dashboard/src/components/FeedSidebar.tsx
@@ -2,21 +2,9 @@ import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { useFeed } from '../hooks/useFeed.js';
 import { cn } from '../lib/utils.js';
+import { relativeTime } from '../lib/feed.js';
 import { WaitingState } from './WaitingState.js';
 import type { FeedEvent } from '@election-night/core/types';
-
-function relativeTime(timestamp: number): string {
-  const diff = Date.now() - timestamp;
-  const seconds = Math.floor(diff / 1000);
-  if (seconds < 60) return 'Just now';
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  const mins = minutes % 60;
-  if (hours < 24) return mins > 0 ? `${hours}h ${mins}m ago` : `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-}
 
 const TYPE_CONFIG: Record<
   string,

--- a/packages/dashboard/src/components/Layout.tsx
+++ b/packages/dashboard/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useState, useMemo } from 'react';
+import { type ReactNode, useState, useMemo, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { cn } from '../lib/utils.js';
 import Logo from './Logo.js';
@@ -16,17 +16,24 @@ const navItems = [
 ];
 
 function Dateline() {
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 30_000);
+    return () => clearInterval(id);
+  }, []);
+
   return (
     <div className="hidden sm:flex items-center justify-between gap-4 text-[11px] uppercase tracking-[0.09em] text-muted-foreground border-b border-border py-1.5 font-label">
       <span>NZ General Election</span>
       <span className="tabular-nums tracking-normal">
-        {new Date().toLocaleDateString('en-NZ', {
+        {now.toLocaleDateString('en-NZ', {
           weekday: 'short',
           day: 'numeric',
           month: 'short',
         })}{' '}
         ·{' '}
-        {new Date().toLocaleTimeString('en-NZ', {
+        {now.toLocaleTimeString('en-NZ', {
           hour: 'numeric',
           minute: '2-digit',
           hour12: true,

--- a/packages/dashboard/src/components/ListCutLinesView.tsx
+++ b/packages/dashboard/src/components/ListCutLinesView.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { partyColors } from '../lib/constants.js';
+import { partyColors, buildElectorateLookup } from '../lib/constants.js';
 import { cn } from '../lib/utils.js';
 import { WaitingState } from './WaitingState.js';
 import type {
@@ -11,16 +11,6 @@ import type {
 
 type ElectorateResult = ElectorateResults & WithLeaders;
 type PartyListEntry = PartyList & WithAdjustedRank;
-
-function buildElectorateLookup(
-  electorateResults: { electorateName: string; leaders: { leadingCandidate: string } }[]
-): Map<string, string> {
-  const map = new Map<string, string>();
-  for (const r of electorateResults) {
-    map.set(r.leaders.leadingCandidate, r.electorateName);
-  }
-  return map;
-}
 
 export function ListCutLinesView({
   partyLists,

--- a/packages/dashboard/src/components/ParliamentSeatGrid.test.tsx
+++ b/packages/dashboard/src/components/ParliamentSeatGrid.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { describe, expect, test, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ParliamentSeatGrid } from './ParliamentSeatGrid.js';
+import type { SeatInfo } from '../lib/parliament.js';
+
+const seats: SeatInfo[] = [
+  { party: 'National Party', color: '#00529F', opacity: 1, type: 'electorate', name: 'Auckland Central' },
+  { party: 'Labour Party', color: '#D82A20', opacity: 1, type: 'electorate', name: 'Mt Albert' },
+  { party: 'Vacant', color: '#888888', opacity: 0.5, type: 'list', name: '' },
+];
+
+const noop = () => {};
+
+describe('ParliamentSeatGrid', () => {
+  test('seats are focusable and support keyboard drag', () => {
+    const onDragStart = vi.fn();
+    const onDrop = vi.fn();
+    const onDragEnd = vi.fn();
+
+    render(
+      <ParliamentSeatGrid
+        seats={seats}
+        draggingParty={null}
+        dropTargetParty={null}
+        hoveredParty={null}
+        selectedSeat={null}
+        onDragStart={onDragStart}
+        onDragEnter={noop}
+        onDragEnd={onDragEnd}
+        onDrop={onDrop}
+        onHover={noop}
+        onSelect={noop}
+      />
+    );
+
+    const nationalSeat = screen.getByLabelText('National Party electorate seat');
+    expect(nationalSeat).toHaveAttribute('tabIndex', '0');
+
+    fireEvent.keyDown(nationalSeat, { key: ' ' });
+    expect(onDragStart).toHaveBeenCalledWith('National Party');
+
+    fireEvent.keyDown(nationalSeat, { key: 'ArrowDown' });
+    fireEvent.keyDown(nationalSeat, { key: 'Enter' });
+    expect(onDrop).toHaveBeenCalledWith('National Party', 'Labour Party');
+    expect(onDragEnd).toHaveBeenCalled();
+  });
+
+  test('vacant seats are not focusable', () => {
+    render(
+      <ParliamentSeatGrid
+        seats={seats}
+        draggingParty={null}
+        dropTargetParty={null}
+        hoveredParty={null}
+        selectedSeat={null}
+        onDragStart={noop}
+        onDragEnter={noop}
+        onDragEnd={noop}
+        onDrop={noop}
+        onHover={noop}
+        onSelect={noop}
+      />
+    );
+
+    const vacantSeat = screen.getByLabelText('Vacant list seat');
+    expect(vacantSeat).toHaveAttribute('tabIndex', '-1');
+  });
+});

--- a/packages/dashboard/src/components/ParliamentSeatGrid.tsx
+++ b/packages/dashboard/src/components/ParliamentSeatGrid.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useRef, useState, useCallback } from 'react';
 import { cn } from '../lib/utils.js';
 import type { SeatInfo } from '../lib/parliament.js';
 
@@ -30,6 +30,66 @@ export function ParliamentSeatGrid({
   onSelect: (index: number, element: HTMLElement) => void;
 }) {
   const gridRef = useRef<HTMLDivElement>(null);
+  const seatRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const [keyboardDragIndex, setKeyboardDragIndex] = useState<number | null>(null);
+  const [keyboardDropIndex, setKeyboardDropIndex] = useState<number | null>(null);
+
+  const isKeyboardDragging = keyboardDragIndex !== null;
+
+  const moveDropTarget = useCallback(
+    (direction: 'up' | 'down' | 'left' | 'right') => {
+      if (keyboardDropIndex === null) return;
+      const max = seats.length - 1;
+      let next = keyboardDropIndex;
+      if (direction === 'up') next = Math.max(0, next - 1);
+      if (direction === 'down') next = Math.min(max, next + 1);
+      if (direction === 'left') next = Math.max(0, next - ROWS);
+      if (direction === 'right') next = Math.min(max, next + ROWS);
+      if (next !== keyboardDropIndex) {
+        setKeyboardDropIndex(next);
+        onDragEnter(seats[next].party);
+      }
+    },
+    [keyboardDropIndex, seats, onDragEnter]
+  );
+
+  const startKeyboardDrag = useCallback(
+    (index: number) => {
+      const seat = seats[index];
+      if (!seat || seat.party === 'Vacant') return;
+      setKeyboardDragIndex(index);
+      setKeyboardDropIndex(index);
+      onDragStart(seat.party);
+    },
+    [seats, onDragStart]
+  );
+
+  const dropKeyboardDrag = useCallback(() => {
+    if (
+      keyboardDragIndex === null ||
+      keyboardDropIndex === null ||
+      keyboardDragIndex === keyboardDropIndex
+    ) {
+      setKeyboardDragIndex(null);
+      setKeyboardDropIndex(null);
+      onDragEnd();
+      return;
+    }
+    const dragged = seats[keyboardDragIndex];
+    const target = seats[keyboardDropIndex];
+    if (dragged && target && dragged.party !== target.party) {
+      onDrop(dragged.party, target.party);
+    }
+    setKeyboardDragIndex(null);
+    setKeyboardDropIndex(null);
+    onDragEnd();
+  }, [keyboardDragIndex, keyboardDropIndex, seats, onDrop, onDragEnd]);
+
+  const cancelKeyboardDrag = useCallback(() => {
+    setKeyboardDragIndex(null);
+    setKeyboardDropIndex(null);
+    onDragEnd();
+  }, [onDragEnd]);
 
   return (
     <div
@@ -61,11 +121,21 @@ export function ParliamentSeatGrid({
           const isDropTarget = dropTargetParty === s.party && !isDragging;
           const isHovered = hoveredParty === s.party && !draggingParty;
           const isSelected = selectedSeat === i && s.party !== 'Vacant';
+          const isKeyboardDragSource = keyboardDragIndex === i;
+          const isKeyboardDropTarget = keyboardDropIndex === i && isKeyboardDragging;
+          const canDrag = s.party !== 'Vacant';
 
           return (
             <div
               key={`${s.party}-${i}`}
-              draggable
+              ref={(el) => { seatRefs.current[i] = el; }}
+              tabIndex={s.party === 'Vacant' ? -1 : 0}
+              role="button"
+              aria-roledescription={canDrag ? 'draggable seat' : 'seat'}
+              aria-label={`${s.party} ${s.type} seat`}
+              aria-grabbed={canDrag ? isKeyboardDragging && isKeyboardDragSource : undefined}
+              aria-dropeffect={canDrag && isKeyboardDragging && !isKeyboardDragSource ? 'move' : undefined}
+              draggable={canDrag}
               onDragStart={() => onDragStart(s.party)}
               onDragEnter={() => onDragEnter(s.party)}
               onDragOver={(e) => e.preventDefault()}
@@ -83,16 +153,58 @@ export function ParliamentSeatGrid({
                   onSelect(i, e.currentTarget);
                 }
               }}
+              onKeyDown={(e) => {
+                if (isKeyboardDragging) {
+                  if (e.key === 'Escape') {
+                    e.preventDefault();
+                    cancelKeyboardDrag();
+                    return;
+                  }
+                  if (e.key === 'ArrowUp' || e.key === 'ArrowDown' || e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+                    e.preventDefault();
+                    moveDropTarget(
+                      e.key === 'ArrowUp'
+                        ? 'up'
+                        : e.key === 'ArrowDown'
+                          ? 'down'
+                          : e.key === 'ArrowLeft'
+                            ? 'left'
+                            : 'right'
+                    );
+                    return;
+                  }
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    dropKeyboardDrag();
+                    return;
+                  }
+                }
+
+                if (!canDrag) return;
+
+                if (e.key === ' ') {
+                  e.preventDefault();
+                  startKeyboardDrag(i);
+                  return;
+                }
+
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  onSelect(i, e.currentTarget);
+                }
+              }}
               className={cn(
-                'aspect-square transition-opacity duration-100',
-                isDragging && 'opacity-50 ring-2 ring-foreground/60',
-                isDropTarget && 'ring-2 ring-brand',
+                'aspect-square transition-opacity duration-100 focus:outline-none focus:ring-2 focus:ring-ring/60 focus:z-10',
+                (isDragging || isKeyboardDragSource) && 'opacity-50 ring-2 ring-foreground/60',
+                (isDropTarget || isKeyboardDropTarget) && 'ring-2 ring-brand',
                 isHovered && 'ring-2 ring-foreground/50 z-10',
                 isSelected && 'ring-2 ring-foreground z-20',
                 !isDragging &&
                   !isDropTarget &&
                   !isHovered &&
                   !isSelected &&
+                  !isKeyboardDragSource &&
+                  !isKeyboardDropTarget &&
                   'ring-1 ring-foreground/15',
                 s.type === 'electorate' ? 'cursor-pointer' : 'cursor-move'
               )}

--- a/packages/dashboard/src/components/ParliamentSeats.tsx
+++ b/packages/dashboard/src/components/ParliamentSeats.tsx
@@ -264,6 +264,7 @@ export default function ParliamentSeats({
       <BottomSheet
         open={selectedSeatInfo !== null && isMobile}
         onClose={() => setSelectedSeat(null)}
+        title={selectedSeatInfo ? `${selectedSeatInfo.party} seat` : 'Seat details'}
       >
         {selectedSeatInfo && (
           <SeatDetailContent

--- a/packages/dashboard/src/components/SeatDetailContent.tsx
+++ b/packages/dashboard/src/components/SeatDetailContent.tsx
@@ -26,6 +26,7 @@ export function SeatDetailContent({
           onClick={onClose}
           className="text-muted-foreground hover:text-foreground text-xs leading-none p-0.5"
           type="button"
+          aria-label="Close details"
         >
           ✕
         </button>

--- a/packages/dashboard/src/components/Toggle.tsx
+++ b/packages/dashboard/src/components/Toggle.tsx
@@ -19,6 +19,8 @@ export function Toggle<T extends string>({
       {options.map((opt) => (
         <button
           key={opt.value}
+          type="button"
+          aria-pressed={value === opt.value}
           className={cn(
             'px-3 py-2 sm:py-1.5 transition-colors min-h-[44px] font-bold',
             value === opt.value

--- a/packages/dashboard/src/hooks/useApi.test.tsx
+++ b/packages/dashboard/src/hooks/useApi.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { useApi } from './useApi.js';
+
+function TestComponent({ url }: { url: string | null }) {
+  const { data, loading, error } = useApi<{ name: string }>(url);
+  return (
+    <div>
+      <div data-testid="loading">{loading ? 'loading' : 'idle'}</div>
+      <div data-testid="error">{error ?? 'none'}</div>
+      <div data-testid="data">{data ? data.name : 'no data'}</div>
+    </div>
+  );
+}
+
+describe('useApi', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('skips fetch when url is null', () => {
+    render(<TestComponent url={null} />);
+    expect(screen.getByTestId('loading')).toHaveTextContent('idle');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test('loads data on success', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ name: 'Auckland Central' }), { status: 200 })
+    );
+
+    render(<TestComponent url="/api/electorate" />);
+    expect(screen.getByTestId('loading')).toHaveTextContent('loading');
+
+    await waitFor(() =>
+      expect(screen.getByTestId('data')).toHaveTextContent('Auckland Central')
+    );
+    expect(screen.getByTestId('loading')).toHaveTextContent('idle');
+    expect(screen.getByTestId('error')).toHaveTextContent('none');
+  });
+
+  test('sets error on non-ok response', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(new Response('Not found', { status: 404 }));
+
+    render(<TestComponent url="/api/missing" />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('error')).toHaveTextContent('HTTP 404')
+    );
+    expect(screen.getByTestId('loading')).toHaveTextContent('idle');
+    expect(screen.getByTestId('data')).toHaveTextContent('no data');
+  });
+
+  test('aborts previous fetch when url changes', async () => {
+    const abort = vi.fn();
+    const controllers: AbortController[] = [];
+    vi.mocked(fetch).mockImplementation((url, init) => {
+      const controller = new AbortController();
+      controllers.push(controller);
+      // Link the global AbortSignal to our controller so we can observe abort.
+      if (init && typeof init === 'object' && 'signal' in init && init.signal) {
+        const signal = init.signal as AbortSignal;
+        signal.addEventListener('abort', () => {
+          abort(signal.reason);
+          controller.abort();
+        });
+      }
+      return new Promise<Response>(() => {
+        // Never resolves.
+      });
+    });
+
+    const { rerender } = render(<TestComponent url="/api/one" />);
+    rerender(<TestComponent url="/api/two" />);
+
+    await waitFor(() => expect(controllers.length).toBeGreaterThanOrEqual(1));
+    // The first request should be aborted when the URL changes.
+    controllers[0].abort();
+    await waitFor(() => expect(abort).toHaveBeenCalled());
+  });
+});

--- a/packages/dashboard/src/hooks/useApi.ts
+++ b/packages/dashboard/src/hooks/useApi.ts
@@ -1,36 +1,59 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 /**
  * Generic JSON fetch hook with loading/error state.
  * Pass `null` as the url to skip fetching entirely.
+ *
+ * The request is aborted when the URL changes or the component unmounts.
  */
 export function useApi<T>(url: string | null) {
   const [data, setData] = useState<T | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  const fetchData = useCallback(async () => {
-    if (url === null) {
-      setData(null);
-      return;
-    }
-    setLoading(true);
-    setError(null);
-    try {
-      const res = await fetch(url);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setData((await res.json()) as T);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Request failed');
-      setData(null);
-    } finally {
-      setLoading(false);
-    }
-  }, [url]);
+  const [tick, setTick] = useState(0);
 
   useEffect(() => {
-    fetchData();
-  }, [fetchData]);
+    if (url === null) {
+      setData(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
 
-  return { data, loading, error, refetch: fetchData };
+    const controller = new AbortController();
+    const { signal } = controller;
+
+    setLoading(true);
+    setError(null);
+
+    fetch(url, { signal })
+      .then((res) => {
+        if (signal.aborted) return;
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((json) => {
+        if (signal.aborted) return;
+        setData(json as T);
+        setError(null);
+      })
+      .catch((err) => {
+        if (signal.aborted) return;
+        setError(err instanceof Error ? err.message : 'Request failed');
+        setData(null);
+      })
+      .finally(() => {
+        if (!signal.aborted) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [url, tick]);
+
+  const refetch = () => setTick((t) => t + 1);
+
+  return { data, loading, error, refetch };
 }

--- a/packages/dashboard/src/hooks/usePartyOrder.ts
+++ b/packages/dashboard/src/hooks/usePartyOrder.ts
@@ -31,7 +31,11 @@ export function usePartyOrder(partyVote: PartyEntry[]) {
 
   useEffect(() => {
     if (order.length > 0) {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(order));
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(order));
+      } catch {
+        /* storage unavailable — order stays in memory for this visit */
+      }
     }
   }, [order]);
 

--- a/packages/dashboard/src/lib/constants.ts
+++ b/packages/dashboard/src/lib/constants.ts
@@ -7,3 +7,26 @@ export const partyColors: Record<string, string> = {
   'Te Pāti Māori': '#000000',
   'The Opportunities Party (TOP)': '#4B0082',
 };
+
+export const MAJOR_PARTY_ORDER = [
+  'National Party',
+  'Labour Party',
+  'Green Party',
+  'ACT New Zealand',
+  'New Zealand First Party',
+] as const;
+
+export const MAJOR_PARTIES = new Set<string>(MAJOR_PARTY_ORDER);
+
+export function buildElectorateLookup(
+  electorateResults: {
+    electorateName: string;
+    leaders: { leadingCandidate: string };
+  }[]
+): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const r of electorateResults) {
+    map.set(r.leaders.leadingCandidate, r.electorateName);
+  }
+  return map;
+}

--- a/packages/dashboard/src/lib/feed.ts
+++ b/packages/dashboard/src/lib/feed.ts
@@ -1,0 +1,22 @@
+/** Shared feed time formatting helpers used by the feed page and sidebar. */
+
+export function relativeTime(timestamp: number): string {
+  const diff = Date.now() - timestamp;
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return 'Just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  if (hours < 24) return mins > 0 ? `${hours}h ${mins}m ago` : `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function formatClockTime(timestamp: number): string {
+  return new Date(timestamp).toLocaleTimeString('en-NZ', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
+}

--- a/packages/dashboard/src/pages/CloseCalls.tsx
+++ b/packages/dashboard/src/pages/CloseCalls.tsx
@@ -5,6 +5,7 @@ import { WaitingState } from '../components/WaitingState.js';
 import { Toggle } from '../components/Toggle.js';
 import { ElectorateRacesView } from '../components/ElectorateRacesView.js';
 import { ListCutLinesView } from '../components/ListCutLinesView.js';
+import { MAJOR_PARTY_ORDER, MAJOR_PARTIES } from '../lib/constants.js';
 import type {
   ElectorateResults,
   WithLeaders,
@@ -15,16 +16,6 @@ import type {
 
 type ElectorateResult = ElectorateResults & WithLeaders & WithMarginOfError;
 type PartyListEntry = PartyList & WithAdjustedRank;
-
-const MAJOR_PARTY_ORDER = [
-  'National Party',
-  'Labour Party',
-  'Green Party',
-  'ACT New Zealand',
-  'New Zealand First Party',
-] as const;
-
-const MAJOR_PARTIES = new Set<string>(MAJOR_PARTY_ORDER);
 
 export default function CloseCalls() {
   const { results } = useResults();

--- a/packages/dashboard/src/pages/Feed.tsx
+++ b/packages/dashboard/src/pages/Feed.tsx
@@ -2,30 +2,10 @@ import { useState, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { useFeed } from '../hooks/useFeed.js';
 import { cn } from '../lib/utils.js';
+import { relativeTime, formatClockTime } from '../lib/feed.js';
 import { TimelineItem, TimelineGroupHeader } from '../components/Timeline.js';
 import { WaitingState } from '../components/WaitingState.js';
 import type { FeedEvent } from '@election-night/core/types';
-
-function formatClockTime(timestamp: number): string {
-  return new Date(timestamp).toLocaleTimeString('en-NZ', {
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true,
-  });
-}
-
-function relativeTime(timestamp: number): string {
-  const diff = Date.now() - timestamp;
-  const seconds = Math.floor(diff / 1000);
-  if (seconds < 60) return 'Just now';
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  const mins = minutes % 60;
-  if (hours < 24) return mins > 0 ? `${hours}h ${mins}m ago` : `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-}
 
 function timeBucket(timestamp: number): number {
   return Math.floor(timestamp / 10000) * 10000;

--- a/packages/dashboard/src/pages/Parties.tsx
+++ b/packages/dashboard/src/pages/Parties.tsx
@@ -2,31 +2,16 @@ import { useEffect, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useResults } from '../hooks/useResults.js';
 import { cn } from '../lib/utils.js';
-import { partyColors } from '../lib/constants.js';
+import {
+  partyColors,
+  MAJOR_PARTY_ORDER,
+  MAJOR_PARTIES,
+  buildElectorateLookup,
+} from '../lib/constants.js';
 import { WaitingState } from '../components/WaitingState.js';
 import type { PartyList, WithAdjustedRank } from '@election-night/core/types';
 
-const MAJOR_PARTY_ORDER = [
-  'National Party',
-  'Labour Party',
-  'Green Party',
-  'ACT New Zealand',
-  'New Zealand First Party',
-] as const;
-
-const MAJOR_PARTIES = new Set<string>(MAJOR_PARTY_ORDER);
-
 type PartyListEntry = PartyList & WithAdjustedRank;
-
-function buildElectorateLookup(
-  electorateResults: { electorateName: string; leaders: { leadingCandidate: string } }[]
-): Map<string, string> {
-  const map = new Map<string, string>();
-  for (const r of electorateResults) {
-    map.set(r.leaders.leadingCandidate, r.electorateName);
-  }
-  return map;
-}
 
 export default function Parties() {
   const { results } = useResults();

--- a/packages/dashboard/src/pages/Seats.tsx
+++ b/packages/dashboard/src/pages/Seats.tsx
@@ -232,7 +232,9 @@ function SuccessfulCandidates({
                     <span>
                       {(c.certainty * 100).toFixed(1)}%{' '}
                       <span className="text-muted-foreground font-medium whitespace-nowrap">
-                        ± {(c.marginOfError! * 100).toFixed(1)}%
+                        {c.marginOfError !== undefined
+                          ? `± ${(c.marginOfError * 100).toFixed(1)}%`
+                          : '—'}
                       </span>
                     </span>
                   ) : (

--- a/packages/dashboard/src/test/feed.test.ts
+++ b/packages/dashboard/src/test/feed.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import type { ComparableResult } from '@election-night/core/diff';
+import { buildFeedEvents } from '../../server/feed-events.js';
+
+function makeResult(
+  overrides: Partial<ComparableResult> & { electorateName: string }
+): ComparableResult {
+  return {
+    votesCounted: 1000,
+    votePercentageCounted: 0.5,
+    marginOfError: 0.02,
+    partyVotes: [],
+    candidateVotes: [],
+    leaders: {
+      leadingCandidate: 'Alice',
+      leadingCandidateParty: 'A',
+      secondCandidate: 'Bob',
+      secondCandidateParty: 'B',
+      margin: 100,
+      marginPercent: 0.05,
+      predictionStatus: 'too-close',
+    },
+    ...overrides,
+  } as ComparableResult;
+}
+
+describe('buildFeedEvents', () => {
+  it('does not generate feed events on the first scrape', () => {
+    const result = makeResult({ electorateName: 'Testville' });
+    const events = buildFeedEvents([], [result]);
+    expect(events).toEqual([]);
+  });
+
+  it('generates an event when vote counts change after the first scrape', () => {
+    const first = makeResult({ electorateName: 'Testville', votesCounted: 1000 });
+    const second = makeResult({
+      electorateName: 'Testville',
+      votesCounted: 2000,
+      votePercentageCounted: 0.75,
+    });
+
+    // Baseline scrape generates nothing.
+    expect(buildFeedEvents([], [first])).toEqual([]);
+
+    // Second scrape generates a result_updated event.
+    const events = buildFeedEvents([first], [second]);
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe('result_updated');
+    expect(events[0]!.electorateName).toBe('Testville');
+  });
+});

--- a/packages/dashboard/src/test/history-upstream.test.ts
+++ b/packages/dashboard/src/test/history-upstream.test.ts
@@ -102,6 +102,24 @@ describe('history source (collector REST API client)', () => {
     await expect(source.snapshotMetas()).rejects.toThrow('unreachable');
   });
 
+  it('clearCache drops cached values', async () => {
+    const fetchMock = vi.fn().mockImplementation(() =>
+      Promise.resolve(jsonResponse(200, [{ snapshotId: 1 }]))
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const source = createHistorySource({
+      baseUrl: 'https://history.example.com',
+      cacheTtlMs: 60_000,
+    });
+
+    await source.snapshotMetas();
+    source.clearCache();
+    await source.snapshotMetas();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it('throws on upstream errors', async () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse(500, {}));
     globalThis.fetch = fetchMock as unknown as typeof fetch;

--- a/packages/dashboard/src/test/static.test.ts
+++ b/packages/dashboard/src/test/static.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateReady } from '../../server/ready-check.js';
+
+describe('serveReady /ready behavior', () => {
+  it('returns ready=true when upstream is reachable even without feed events', () => {
+    expect(evaluateReady(true, 'none')).toEqual({
+      ready: true,
+      checks: { history: 'upstream', lastScrape: 'none' },
+    });
+  });
+
+  it('returns ready=false when upstream is unreachable', () => {
+    expect(evaluateReady(false, 'none')).toEqual({
+      ready: false,
+      checks: { history: 'error', lastScrape: 'none' },
+    });
+  });
+
+  it('includes the last feed event timestamp when feed events exist', () => {
+    expect(evaluateReady(true, 12345)).toEqual({
+      ready: true,
+      checks: { history: 'upstream', lastScrape: 12345 },
+    });
+  });
+
+  it('still reports lastScrape when upstream is unreachable', () => {
+    expect(evaluateReady(false, 67890)).toEqual({
+      ready: false,
+      checks: { history: 'error', lastScrape: 67890 },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the review findings across the collector, dashboard server, and frontend. Verified: `npm run build:core`, `npm run typecheck`, `npm run lint`, `npm test -- --run` (26 files, 245 tests) all pass.

## Collector

- **Zero/NaN guards** — `reducers.ts` and `db.ts` no longer divide by zero when `votePercentageCounted`/`votesCounted` is 0; `marginOfError` is stored as `null` when non-finite.
- **Cloudflare challenge validation** — `scrape-cycle.ts` rejects challenge pages per-electorate and falls back to cached results instead of parsing zeros.
- **Webhook reliability** — `retry.ts` retries non-ok responses; `results.ts` emits the error metric on HTTP failures.
- **Socket queue** — `ws-client.ts` caps `pendingResults` and logs dropped metrics.
- **DB ordering** — `index.ts` persists to DB before webhooks/cache/socket publish.
- **Security/startup** — `source-loader.ts` validates `ELECTION_SOURCE_PATH`; startup wrapped in `async main()` with error handling.
- **Cleanup** — fixed misleading rate-limit comment, `clear.ts` dbPath, `serve-mock.ts` hardening, swallowed Playwright rejections, custom-source args.

## Dashboard server

- **Feed correctness** — async mutex serializes `results_update`/`clear`; first scrape no longer floods the feed; `HistorySource.clearCache()` invalidated on `/api/clear`; `/ready` based on upstream reachability.

## Frontend

- **ElectorateMap** — abort/error handling, stable GeoJSON key, memoized lookups, rAF cleanup, payload validation.
- **useApi** — `AbortController` prevents stale-response races.
- **Accessibility** — ElectorateSearch combobox, ElectorateRacesView rows, ParliamentSeatGrid keyboard drag, BottomSheet dialog semantics, Toggle `aria-pressed`, SeatDetailContent close label.
- **Dedup** — shared party order/electorate lookup and feed time helpers; live Dateline clock; guarded `localStorage`; removed non-null assertions.

## Config/infra

- Documented missing env vars, ignored `.env.*` variants, noted `HISTORY_UPSTREAM` requirement.

## Tests added

`reducers.test.ts`, `scrape-cycle.test.ts`, plus dashboard tests for `useApi`, `ElectorateSearch`, `ElectorateRacesView`, `ParliamentSeatGrid`, `BottomSheet`, `feed`, `history-upstream`, and `static`.