### PR TITLE
Update deployment docs and add 2026 electorate list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,5 +120,5 @@ npm run fmt           # prettier --write .
 
 ## Deployment
 
-- Production is split: the **dashboard server runs on Fly.io** (`fly.toml` + `Dockerfile.dashboard`, a server-only image — no browser, no SQLite) and the **collector runs on a homelab LXC via Coolify** (`Dockerfile.collector`). The collector publishes to the cloud server over Socket.io (`WS_URL`) and serves `/history/*` on port 3459, which the cloud server reads via `HISTORY_UPSTREAM`.
+- Production is split: the **dashboard server runs on Fly.io** (`fly.toml` + `Dockerfile.dashboard`, a server-only image — no browser, no SQLite) and the **collector runs separately** (`Dockerfile.collector`) wherever it has suitable egress — the results site WAF-blocks datacenter IPs, so it typically needs a residential connection or a residential proxy (`CLOAKBROWSER_PROXY`); the hosting choice is up to you. The collector publishes to the dashboard server over Socket.io (`WS_URL`) and serves `/history/*` on port 3459, which the dashboard server reads via `HISTORY_UPSTREAM`.
 - CI: `.github/workflows/deploy.yml` deploys `main` to Fly, gated on `checks.yml` (lint/typecheck/test) and `security.yml`; `preview.yml` deploys per-PR preview apps.

--- a/Dockerfile.collector
+++ b/Dockerfile.collector
@@ -1,10 +1,11 @@
-# Collector-only image for homelab deployments (e.g. Coolify on a Proxmox LXC).
+# Collector-only image; run it wherever it has suitable network egress
+# (see the notes in README.md on datacenter-IP blocking).
 #
 # Builds @election-night/core + the collector, installs the stealth Chromium,
 # and runs the scraper loop. Outbound-only except port 3459: the collector is
-# a Socket.io *client* (publishes results to the cloud dashboard server) and
+# a Socket.io *client* (publishes results to the dashboard server) and
 # serves /health plus the unauthenticated /history/* REST API that the
-# cloud dashboard server reads via HISTORY_UPSTREAM — see
+# dashboard server reads via HISTORY_UPSTREAM — see
 # packages/collector/src/history-server.ts.
 #
 # Mirrors the root Dockerfile's build pattern (prebuilt better-sqlite3,
@@ -83,7 +84,7 @@ COPY --from=builder /app /app
 EXPOSE 3459
 
 # Healthcheck: the state server on 3459 must answer (wget ships in this
-# image). Note: Coolify does not auto-restart unhealthy containers — the
+# image). Some orchestrators do not auto-restart unhealthy containers — the
 # restart policy recovers crashes; this check exists for stall visibility.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
   CMD wget -q -O - http://127.0.0.1:3459/health || exit 1

--- a/Dockerfile.dashboard
+++ b/Dockerfile.dashboard
@@ -1,6 +1,6 @@
 # Server-only image for the dashboard server (deployed to Fly.io).
 #
-# The collector runs separately on the homelab (see Dockerfile.collector) and
+# The collector runs separately (see Dockerfile.collector) and
 # publishes to this server over Socket.io; history data arrives via the
 # collector's /history/* REST API (HISTORY_UPSTREAM). No browser, no SQLite —
 # nothing here launches cloakbrowser, so the image stays slim.

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Other flags: `--port 3457` (or `MOCK_PORT`), `--help`.
 | `CACHE_PATH`                    | `.data/electorate_results.json`                        | Dashboard server JSON cache path                                                                                                                                                                                           |
 | `FEED_CACHE_PATH`               | `.data/feed_events.json`                               | Dashboard server feed-events cache path                                                                                                                                                                                    |
 | `MAX_FEED_EVENTS`               | `200`                                                  | Maximum feed events retained by the dashboard server                                                                                                                                                                       |
-| `HISTORY_UPSTREAM`              | `http://127.0.0.1:3459`                                | Dashboard server: base URL of the collector's history REST API — the server's _only_ source of history data. Default suits a co-located collector; point it at the homelab collector in split deployments                  |
+| `HISTORY_UPSTREAM`              | `http://127.0.0.1:3459`                                | Dashboard server: base URL of the collector's history REST API — the server's _only_ source of history data. Default suits a co-located collector; point it at the collector in split deployments                  |
 | `DIST_DIR`                      | `./dist`                                               | Directory the dashboard server serves static files from                                                                                                                                                                    |
 | `OPENAI_API_KEY`                | —                                                      | API key for the `discover` subcommand                                                                                                                                                                                      |
 | `OPENAI_BASE_URL`               | `https://api.openai.com/v1`                            | Base URL for the LLM used by `discover`                                                                                                                                                                                    |
@@ -158,7 +158,7 @@ Other flags: `--port 3457` (or `MOCK_PORT`), `--help`.
 
 ## Deployment
 
-Production is a two-machine setup: the **dashboard server runs in the cloud** (Fly.io, server-only) and the **collector runs on a homelab box** with residential-IP egress, publishing results to the cloud server over Socket.io.
+The components can be deployed together or split across machines: the **dashboard server** runs as a server-only workload (e.g. Fly.io) and the **collector** runs wherever it has suitable network egress — the results site WAF-blocks datacenter IPs, so it typically needs a residential connection or a residential proxy (`CLOAKBROWSER_PROXY`). The collector publishes results to the dashboard server over Socket.io. Where you run each component is up to you; the only hard requirement is the collector's egress.
 
 ### Docker
 
@@ -171,11 +171,11 @@ The image is **server-only** (the collector never runs in it — no browser, no 
 
 ### Fly.io (dashboard server)
 
-`fly.toml` deploys the server (built from `Dockerfile.dashboard`); the collector publishes to it from the homelab over Socket.io (`WS_URL`) and serves history over HTTP (point `HISTORY_UPSTREAM` at it via `fly secrets set`). JSON caches (`.data/`) are ephemeral — after a restart the feed rebuilds from the next collector publish. Pushes to `main` deploy automatically via `.github/workflows/deploy.yml` (gated on lint/typecheck/tests plus `security.yml` audits), and PR previews are deployed by `.github/workflows/preview.yml`.
+`fly.toml` deploys the server (built from `Dockerfile.dashboard`); the collector publishes to it over Socket.io (`WS_URL`) and serves history over HTTP (point `HISTORY_UPSTREAM` at it via `fly secrets set`). JSON caches (`.data/`) are ephemeral — after a restart the feed rebuilds from the next collector publish. Pushes to `main` deploy automatically via `.github/workflows/deploy.yml` (gated on lint/typecheck/tests plus `security.yml` audits), and PR previews are deployed by `.github/workflows/preview.yml`.
 
-### Homelab collector (Coolify)
+### Collector
 
-`Dockerfile.collector` builds a collector-only image for deployment on a residential connection (e.g. Coolify on a Proxmox LXC). It serves a health/live-state endpoint on port 3459, plus the `/history/*` REST API (public data, unauthenticated — rate limit at the proxy if you expose it) which the cloud dashboard server reads via `HISTORY_UPSTREAM` so the Trends page works across the split deployment.
+`Dockerfile.collector` builds a collector-only image you can run wherever suits — a VM, container host, or bare metal — provided the egress IP is acceptable to the results site (residential connection or proxy). It serves a health/live-state endpoint on port 3459, plus the `/history/*` REST API (public data, unauthenticated — rate limit at the proxy if you expose it) which the dashboard server reads via `HISTORY_UPSTREAM` so the Trends page works across a split deployment.
 
 ## Custom Source Adapters
 

--- a/csv/electorates_2026.csv
+++ b/csv/electorates_2026.csv
@@ -1,0 +1,71 @@
+Auckland Central
+Banks Peninsula
+Botany
+Christchurch Central
+Christchurch East
+Coromandel
+Dunedin
+East Cape
+East Coast Bays
+Epsom
+Glendene
+Hamilton East
+Hamilton West
+Henderson
+Hutt South
+Ilam
+Invercargill
+Kaikōura
+Kaipara ki Mahurangi
+Kapiti
+Kenepuru
+Māngere
+Manurewa
+Maungakiekie
+Mt Albert
+Mt Maunganui
+Mt Roskill
+Napier
+Nelson
+New Plymouth
+North Shore
+Northcote
+Northland
+Ōtāhuhu
+Pakuranga
+Palmerston North
+Papakura
+Port Waikato
+Rangitata
+Rangitīkei
+Remutaka
+Rotorua
+Selwyn
+Southland
+Taieri
+Takanini
+Tāmaki
+Taranaki-King Country
+Taupō
+Tauranga
+Tukituki
+Upper Harbour
+Waikato
+Waimakariri
+Wairarapa
+Waitākere
+Waitaki
+Wellington Bays
+Wellington North
+West Coast-Tasman
+Whanganui
+Whangaparāoa
+Whangārei
+Wigram
+Hauraki-Waikato
+Ikaroa-Rāwhiti
+Tāmaki Makaurau
+Te Tai Hauāuru
+Te Tai Tokerau
+Te Tai Tonga
+Waiariki

--- a/packages/dashboard/server/config.ts
+++ b/packages/dashboard/server/config.ts
@@ -16,7 +16,7 @@ const dashboardServerConfigSchema = z.object({
     .url()
     .default('http://127.0.0.1:3459')
     .describe(
-      'Base URL of the collector history REST API. The server never reads a SQLite DB — it always fetches /api/history/* from here. Default suits a co-located collector; point it at the homelab collector in split deployments'
+      'Base URL of the collector history REST API. The server never reads a SQLite DB — it always fetches /api/history/* from here. Default suits a co-located collector; point it at the collector in split deployments'
     ),
   clearToken: z
     .string()


### PR DESCRIPTION
## Summary

Documentation and data updates that were sitting uncommitted in the working tree, separate from the review-fixes PR (#44).

## Changes

- **AGENTS.md / README.md / Dockerfile.collector / Dockerfile.dashboard** — removed homelab/Coolify-specific deployment references. The collector is now described as deployable anywhere with suitable network egress (VM, container host, or bare metal), not tied to a specific homelab stack.
- **packages/dashboard/server/config.ts** — aligned the `HISTORY_UPSTREAM` description with the generalized deployment wording.
- **csv/electorates_2026.csv** — new 2026 electorate boundaries list (71 electorates: 64 general + 7 Māori), reflecting the 2026 boundary changes (e.g. East Cape, Glendene, Henderson, Kapiti, Kenepuru, Mt Maunganui, Ōtāhuhu, Waitākere, Wellington Bays, Wellington North).

## Note

This is intentionally separate from #44 (the code review fixes). No code changes here — docs and data only.