### PR TITLE
ci: skip PR preview deploys for dependabot

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,6 +8,10 @@ env:
 
 jobs:
   preview:
+    # Dependabot-triggered runs have no access to GitHub Actions secrets
+    # (FLY_API_TOKEN) and a read-only GITHUB_TOKEN, so preview deploys would
+    # always fail for them. Skip entirely to avoid the noise.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
## Summary

Dependabot-triggered workflow runs treat the PR as coming from a fork: **no access to GitHub Actions secrets** (`FLY_API_TOKEN` resolves empty) and a **read-only** `GITHUB_TOKEN`. Every dependabot PR has failed the preview deploy with:

```
Error: no access token available. Please login with 'flyctl auth login'
```

This adds a job-level guard so dependabot PRs skip the preview entirely (job shows as *skipped* on the checks list instead of *failed*). The deploy step already destroys orphaned apps, so nothing leaks for skipped runs.

## Test Plan

- [ ] Checks run green on this PR (human actor → preview deploys as normal)
- [ ] Next dependabot PR shows preview as skipped, not failed